### PR TITLE
Fix typo in everest.yaml

### DIFF
--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CollabUtils2
   Version: 1.0.0
-  DLL: bin/Debug/net45/CollabUtils2.dll
+  DLL: bin/Debug/net452/CollabUtils2.dll
   Dependencies:
     - Name: Everest
       Version: 1.1311.0


### PR DESCRIPTION
/net45/ -> /net452/

same as in SpringCollab2020