### PR TITLE
Changes to the in-game chapter panel

### DIFF
--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -7,3 +7,5 @@ Art by Pedro Medeiros
 Music by Lena Raine
 Something Something
 Totally a collab map
+
+area_1_author= by max480

--- a/UI/InGameOverworldHelper.cs
+++ b/UI/InGameOverworldHelper.cs
@@ -2,7 +2,9 @@
 using Celeste.Mod.CollabUtils2.UI;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
+using Mono.Cecil.Cil;
 using Monocle;
+using MonoMod.Cil;
 using MonoMod.Utils;
 using System;
 using System.Collections;
@@ -37,6 +39,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             On.Celeste.OuiChapterPanel.Swap += OnChapterPanelSwap;
             On.Celeste.OuiChapterPanel.DrawCheckpoint += OnChapterPanelDrawCheckpoint;
             On.Celeste.OuiJournal.Enter += OnJournalEnter;
+            IL.Celeste.OuiChapterPanel.Render += ModOuiChapterPanelEnter;
         }
 
         public static void Unload() {
@@ -49,6 +52,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             On.Celeste.OuiChapterPanel.Swap -= OnChapterPanelSwap;
             On.Celeste.OuiChapterPanel.DrawCheckpoint -= OnChapterPanelDrawCheckpoint;
             On.Celeste.OuiJournal.Enter -= OnJournalEnter;
+            IL.Celeste.OuiChapterPanel.Render -= ModOuiChapterPanelEnter;
         }
 
         private static void OnPause(Level level, int startIndex, bool minimal, bool quickReset) {
@@ -87,8 +91,8 @@ namespace Celeste.Mod.CollabUtils2.UI {
             save.LastArea = forceArea.ToKey();
             save.CurrentSession = null;
 
-            List<OuiChapterSelectIcon> icons = self.Overworld.Entities.FindAll<OuiChapterSelectIcon>();
-            OuiChapterSelectIcon icon = icons[save.LastArea.ID];
+            dynamic ouiChapterSelect = new DynamicData(self.Overworld.GetUI<OuiChapterSelect>());
+            OuiChapterSelectIcon icon = ouiChapterSelect.icons[save.LastArea.ID];
             icon.SnapToSelected();
             icon.Add(new Coroutine(UpdateIconRoutine(self, icon)));
 
@@ -96,6 +100,11 @@ namespace Celeste.Mod.CollabUtils2.UI {
 
             dynamic data = new DynamicData(self);
             data.hasCollabCredits = true;
+
+            string author = (new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea").Name + "_author").DialogCleanOrNull();
+            if (author != null) {
+                data.chapter = author;
+            }
 
             /*
             (data.modes as IList).Add(
@@ -142,7 +151,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 orig(self);
                 return;
             }
-            
+
             data.collabCredits = Dialog.Clean(new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea").Name + "_collabcredits");
             self.Focused = false;
             self.Overworld.ShowInputUI = !selectingMode;
@@ -152,7 +161,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private static IEnumerator ChapterPanelSwapRoutine(OuiChapterPanel self, dynamic data) {
             float fromHeight = data.height;
             int toHeight = 730;
-            
+
             data.resizing = true;
             data.PlayExpandSfx(fromHeight, (float) toHeight);
 
@@ -214,6 +223,26 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 Vector2.One,
                 Color.Black * 0.8f
             );
+        }
+
+        private static void ModOuiChapterPanelEnter(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdcR4(-2f) || instr.MatchLdcR4(-18f))) {
+                Logger.Log("CollabUtils2/InGameOverworldHelper", $"Modding chapter panel title position at {cursor.Index} in IL for OuiChapterPanel.Render");
+
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate<Func<float, OuiChapterPanel, float>>(moveAroundPanelHeader);
+            }
+        }
+
+        private static float moveAroundPanelHeader(float orig, OuiChapterPanel self) {
+            AreaData forceArea = self.Overworld == null ? null : new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea");
+            if (forceArea != null) {
+                return orig == -18f ? -49f : 43f;
+            } else {
+                return orig;
+            }
         }
 
         private static IEnumerator OnJournalEnter(On.Celeste.OuiJournal.orig_Enter orig, OuiJournal self, Oui from) {

--- a/UI/InGameOverworldHelper.cs
+++ b/UI/InGameOverworldHelper.cs
@@ -101,10 +101,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             dynamic data = new DynamicData(self);
             data.hasCollabCredits = true;
 
-            string author = (new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea").Name + "_author").DialogCleanOrNull();
-            if (author != null) {
-                data.chapter = author;
-            }
+            data.chapter = Dialog.Clean(new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea").Name + "_author");
 
             /*
             (data.modes as IList).Add(

--- a/UI/InGameOverworldHelper.cs
+++ b/UI/InGameOverworldHelper.cs
@@ -213,11 +213,14 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 return;
             }
 
+            Vector2 size = ActiveFont.Measure(collabCredits);
+            float scale = Math.Min(1f, Math.Min(410f / size.Y, 800f / size.X));
+
             ActiveFont.Draw(
                 collabCredits,
                 center + new Vector2(0f, 40f),
                 Vector2.One * 0.5f,
-                Vector2.One,
+                Vector2.One * scale,
                 Color.Black * 0.8f
             );
         }


### PR DESCRIPTION
This PR contains the following changes to the in-game chapter panel:
- display the mapper name like this instead of the chapter number:
![image](https://user-images.githubusercontent.com/52103563/80414220-fd272e80-88d0-11ea-97cb-af4848f718e9.png)
- a slight change on code getting the map icon, since the existing code had a weird off by one issue (map 21 showing the icon of map 22)
- have the size of credits text be automatically resized if the text wouldn't fit in the panel, like this:
![image](https://user-images.githubusercontent.com/52103563/80421758-42e9f400-88dd-11ea-8f89-e6b4889e8b51.png)
