### PR TITLE
"Return to lobby" button

### DIFF
--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -31,7 +31,7 @@ namespace Celeste.Mod.CollabUtils2 {
         public override void LoadSession(int index, bool forceNew) {
             base.LoadSession(index, forceNew);
 
-            if(forceNew) {
+            if (forceNew) {
                 ReturnToLobbyHelper.OnSessionCreated();
             }
         }

--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -1,13 +1,17 @@
 ﻿using Celeste.Mod.CollabUtils2.Triggers;
 using Celeste.Mod.CollabUtils2.UI;
 using Microsoft.Xna.Framework;
+using System;
 using System.Linq;
 
 namespace Celeste.Mod.CollabUtils2 {
     public class CollabModule : EverestModule {
 
         public static CollabModule Instance;
-        
+
+        public override Type SessionType => typeof(CollabSession);
+        public CollabSession Session => _Session as CollabSession;
+
         public CollabModule() {
             Instance = this;
         }
@@ -15,11 +19,21 @@ namespace Celeste.Mod.CollabUtils2 {
         public override void Load() {
             Everest.Events.Level.OnLoadEntity += OnLoadEntity;
             InGameOverworldHelper.Load();
+            ReturnToLobbyHelper.Load();
         }
 
         public override void Unload() {
             Everest.Events.Level.OnLoadEntity -= OnLoadEntity;
             InGameOverworldHelper.Unload();
+            ReturnToLobbyHelper.Unload();
+        }
+
+        public override void LoadSession(int index, bool forceNew) {
+            base.LoadSession(index, forceNew);
+
+            if(forceNew) {
+                ReturnToLobbyHelper.OnSessionCreated();
+            }
         }
 
         private static bool OnLoadEntity(Level level, LevelData levelData, Vector2 offset, EntityData entityData) {

--- a/CollabSession.cs
+++ b/CollabSession.cs
@@ -1,0 +1,6 @@
+﻿
+namespace Celeste.Mod.CollabUtils2 {
+    public class CollabSession : EverestModuleSession {
+        public string LobbySID { get; set; } = null;
+    }
+}

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -1,3 +1,5 @@
+collabutils2_returntolobby= Return to Lobby
+
 # SHIP COLLAB-SPECIFIC DIALOG WITH THE COLLAB MOD, NOT THE COLLAB UTILS.
 
 area_1_collabcredits= 

--- a/Dialog/French.txt
+++ b/Dialog/French.txt
@@ -1,0 +1,1 @@
+﻿collabutils2_returntolobby= Retour au lobby

--- a/UI/ReturnToLobbyHelper.cs
+++ b/UI/ReturnToLobbyHelper.cs
@@ -1,0 +1,78 @@
+﻿using Monocle;
+using MonoMod.Utils;
+
+namespace Celeste.Mod.CollabUtils2.UI {
+    class ReturnToLobbyHelper {
+        private static string temporaryLobbySIDHolder;
+
+        public static void Load() {
+            On.Celeste.OuiChapterPanel.Start += modChapterPanelStart;
+            Everest.Events.Level.OnCreatePauseMenuButtons += onCreatePauseMenuButtons;
+            On.Celeste.LevelExit.ctor += onLevelExitConstructor;
+        }
+
+        public static void Unload() {
+            On.Celeste.OuiChapterPanel.Start -= modChapterPanelStart;
+            Everest.Events.Level.OnCreatePauseMenuButtons -= onCreatePauseMenuButtons;
+            On.Celeste.LevelExit.ctor -= onLevelExitConstructor;
+        }
+
+        private static void modChapterPanelStart(On.Celeste.OuiChapterPanel.orig_Start orig, OuiChapterPanel self, string checkpoint) {
+            AreaData forceArea = self.Overworld == null ? null : new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea");
+            if (forceArea != null) {
+                // current chapter panel is in-game: save the current map in the temporaryLobbyNameHolder variable.
+                temporaryLobbySIDHolder = (Engine.Scene as Level)?.Session?.MapData?.Area.GetSID();
+            }
+
+            orig(self, checkpoint);
+        }
+
+        public static void OnSessionCreated() {
+            // transfer the lobby SID into the session that was just created.
+            CollabModule.Instance.Session.LobbySID = temporaryLobbySIDHolder;
+            temporaryLobbySIDHolder = null;
+        }
+
+        private static void onCreatePauseMenuButtons(Level level, TextMenu menu, bool minimal) {
+            if (CollabModule.Instance.Session.LobbySID != null) {
+                int returnToMapIndex = menu.GetItems().FindIndex(item =>
+                    item.GetType() == typeof(TextMenu.Button) && ((TextMenu.Button) item).Label == Dialog.Clean("MENU_PAUSE_RETURN"));
+
+                menu.Insert(returnToMapIndex, new TextMenu.Button(Dialog.Clean("collabutils2_returntolobby"))
+                    .Pressed(() => {
+                        Engine.TimeRate = 1f;
+                        menu.Focused = false;
+                        Audio.SetMusic(null);
+                        Audio.BusStopAll("bus:/gameplay_sfx", immediate: true);
+
+                        level.DoScreenWipe(wipeIn: false, () => {
+                            // restart chapter... into the lobby
+                            level.Session.Area = AreaData.Get(CollabModule.Instance.Session.LobbySID).ToKey();
+                            level.Session.Level = level.Session.MapData.StartLevel().Name;
+                            Engine.Scene = new LevelExit(LevelExit.Mode.Restart, level.Session);
+
+                            // wipe the lobby SID, we're going to the lobby
+                            temporaryLobbySIDHolder = null;
+                        });
+
+                        foreach (LevelEndingHook component in level.Tracker.GetComponents<LevelEndingHook>()) {
+                            component.OnEnd?.Invoke();
+                        }
+                    }));
+            }
+        }
+
+        private static void onLevelExitConstructor(On.Celeste.LevelExit.orig_ctor orig, LevelExit self, LevelExit.Mode mode, Session session, HiresSnow snow) {
+            orig(self, mode, session, snow);
+
+            if (mode == LevelExit.Mode.Restart || mode == LevelExit.Mode.GoldenBerryRestart) {
+                // be sure to keep the lobby SID in the session, even if we are resetting it.
+                temporaryLobbySIDHolder = CollabModule.Instance.Session.LobbySID;
+            }
+            if (CollabModule.Instance.Session.LobbySID != null) {
+                // be sure that Return to Map and such from a collab entry returns to the lobby, not to the collab entry. 
+                SaveData.Instance.LastArea_Safe = AreaData.Get(CollabModule.Instance.Session.LobbySID).ToKey();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #7.

The strategy is: when we go into a level from an in-game chapter panel, save the level SID we are currently in in the mod session. If the player hits Restart Chapter or dies with a golden, carry over the lobby SID from the current session into the new session. If the player hits Return to Lobby, restart the chapter... into the lobby, and clear the current lobby SID in session. Also, force LastArea to be the lobby, so that Return to Map focuses on the lobby instead of the collab entry (which will eventually be hidden).