### PR TITLE
Set session flags for completed maps in lobbies

### DIFF
--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -33,6 +33,7 @@ namespace Celeste.Mod.CollabUtils2 {
 
             if (forceNew) {
                 ReturnToLobbyHelper.OnSessionCreated();
+                LobbyHelper.OnSessionCreated();
             }
         }
 

--- a/LobbyHelper.cs
+++ b/LobbyHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+
+namespace Celeste.Mod.CollabUtils2 {
+    class LobbyHelper {
+        /// <summary>
+        /// Returns the level set the given lobby SID is associated to, or null if the SID given is not a lobby.
+        /// </summary>
+        /// <param name="sid">The SID for a map</param>
+        /// <returns>The level set name for this lobby, or null if the SID given is not a lobby</returns>
+        public static string GetLobbyLevelSet(string sid) {
+            if (sid.StartsWith("SpringCollab2020/0-Lobbies/")) {
+                return "SpringCollab2020/" + sid.Substring("SpringCollab2020/0-Lobbies/".Length);
+            }
+            return null;
+        }
+
+        public static void OnSessionCreated() {
+            Session session = SaveData.Instance.CurrentSession_Safe;
+            string levelSet = GetLobbyLevelSet(session.Area.GetSID());
+            if (levelSet != null) {
+                // set session flags for each completed map in the level set.
+                // this will allow, for example, stylegrounds to get activated after completing a map.
+                foreach (string mapName in SaveData.Instance.GetLevelSetStatsFor(levelSet).Areas
+                    .Where(area => area.Modes[0].HeartGem)
+                    .Select(area => area.GetSID().Substring(levelSet.Length + 1))) {
+
+                    session.SetFlag($"CollabUtils2_MapCompleted_{mapName}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows, for example, to make stylegrounds appear in the lobby once you completed a map.

Note: the current collab packaging has maps grouped in 5 levelsets (1-Beginner to 5-Grandmaster), the lobbies being in 0-Lobbies. So, we can make `SpringCollab2020/0-Lobbies/1-Beginner` the lobby for the `SpringCollab2020/1-Beginner` levelset. This is what I went for here.

The LobbyHelper class can be reused later to add some more behavior specific to collab lobbies, like them displaying the total berry count in chapter select instead of their own berry count.