### PR TITLE
Get rid of Microsoft.CSharp reference and most DynamicData usage

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -33,7 +33,7 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       run: |
         ZIPNAME=$ZIPNAME-${GITHUB_SHA:0:8}.zip
-        zip -qq -r $ZIPNAME everest.yaml bin/Debug/net452 Ahorn Graphics Audio
+        zip -qq -r $ZIPNAME everest.yaml bin/Debug/net452 Ahorn Graphics Audio Dialog
         url=$(curl -H 'Content-Type: multipart/form-data' -X POST -F "file=@$ZIPNAME" "$DISCORD_WEBHOOK" | grep -Po 'cdn.discordapp.com\/.*?\.zip' | tr -d '\n')
         msg=$(git log -n 1 "--format=%B" | head -n 1 | tr -d '\n')
         curl -H 'Content-Type: application/json' -X POST -d "$(jq -n \

--- a/CollabUtils2.csproj
+++ b/CollabUtils2.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="MonoMod.RuntimeDetour" Version="20.5.2.5" PrivateAssets="all" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <Choose>

--- a/UI/ReturnToLobbyHelper.cs
+++ b/UI/ReturnToLobbyHelper.cs
@@ -21,7 +21,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
         }
 
         private static void modChapterPanelStart(On.Celeste.OuiChapterPanel.orig_Start orig, OuiChapterPanel self, string checkpoint) {
-            AreaData forceArea = self.Overworld == null ? null : new DynamicData(self.Overworld).Get<AreaData>("collabInGameForcedArea");
+            AreaData forceArea = self.Overworld == null ? null : new DynData<Overworld>(self.Overworld).Get<AreaData>("collabInGameForcedArea");
             if (forceArea != null) {
                 // current chapter panel is in-game: save the current map and room.
                 temporaryLobbySIDHolder = (Engine.Scene as Level)?.Session?.MapData?.Area.GetSID();


### PR DESCRIPTION
DynamicData makes for way easier to read syntax, but using the dynamic keyword makes the Linux version want to resolve Microsoft.CSharp (which isn't provided with the game) and using `new DynamicData(self).Invoke("PlayExpandSfx", fromHeight, (float) toHeight)` seems to lead to a core dump. `DynamicData.New` seems (_thankfully_) to cause no issues though.