### PR TITLE
Add a 'return to lobby' mode option to chapter panel triggers

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -1,5 +1,6 @@
 ﻿# Chapter Panel Trigger
 placements.triggers.CollabUtils2/ChapterPanelTrigger.tooltips.map=The SID (string ID) of the map that will be entered with the trigger.
+placements.triggers.CollabUtils2/ChapterPanelTrigger.tooltips.returnToLobbyMode=Determines how "Return to Lobby" will behave after entering this map.\n- SetReturnToHere: the Return to Lobby button will return the player to the nearest spawn point in the current map.\n- RemoveReturn: the Return to Lobby button will disappear from the pause menu.\n- DoNotChangeReturn: the current Return to Lobby button will not be changed.
 
 # Journal Trigger
 placements.triggers.CollabUtils2/JournalTrigger.tooltips.levelset=The levelset for which the journal will be opened with the trigger.

--- a/Ahorn/triggers/chapterPanelTrigger.jl
+++ b/Ahorn/triggers/chapterPanelTrigger.jl
@@ -3,7 +3,7 @@ module CollabUtils2ChapterPanelTrigger
 using ..Ahorn, Maple
 
 @mapdef Trigger "CollabUtils2/ChapterPanelTrigger" ChapterPanelTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
-    map::String="Celeste/1-ForsakenCity")
+    map::String="Celeste/1-ForsakenCity", returnToLobbyMode::String="SetReturnToHere")
 
 const placements = Ahorn.PlacementDict(
     "Chapter Panel Trigger (Collab Utils 2)" => Ahorn.EntityPlacement(
@@ -14,7 +14,7 @@ const placements = Ahorn.PlacementDict(
 
 function Ahorn.editingOptions(trigger::ChapterPanelTrigger)
     return Dict{String, Any}(
-        "positionMode" => Maple.trigger_position_modes
+        "returnToLobbyMode" => String["SetReturnToHere", "RemoveReturn", "DoNotChangeReturn"]
     )
 end
 

--- a/Triggers/ChapterPanelTrigger.cs
+++ b/Triggers/ChapterPanelTrigger.cs
@@ -12,18 +12,25 @@ namespace Celeste.Mod.CollabUtils2.Triggers {
     [CustomEntity("CollabUtils2/ChapterPanelTrigger")]
     public class ChapterPanelTrigger : Trigger {
 
+        public enum ReturnToLobbyMode {
+            SetReturnToHere, RemoveReturn, DoNotChangeReturn
+        }
+
         public string map;
+
+        public ReturnToLobbyMode returnToLobbyMode;
 
         private readonly TalkComponent talkComponent;
 
         public ChapterPanelTrigger(EntityData data, Vector2 offset)
             : base(data, offset) {
             map = data.Attr("map");
+            returnToLobbyMode = data.Enum("returnToLobbyMode", ReturnToLobbyMode.SetReturnToHere);
 
             Add(talkComponent = new TalkComponent(
                 new Rectangle(0, 0, data.Width, data.Height),
                 data.Nodes.Length != 0 ? (data.Nodes[0] - data.Position) : new Vector2(data.Width / 2f, data.Height / 2f),
-                player => InGameOverworldHelper.OpenChapterPanel(player, map)
+                player => InGameOverworldHelper.OpenChapterPanel(player, map, returnToLobbyMode)
             ) { PlayerMustBeFacing = false });
         }
 

--- a/UI/InGameOverworldHelper.cs
+++ b/UI/InGameOverworldHelper.cs
@@ -1,4 +1,5 @@
-﻿using Celeste.Mod.Entities;
+﻿using Celeste.Mod.CollabUtils2.Triggers;
+using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using Monocle;
@@ -274,15 +275,16 @@ namespace Celeste.Mod.CollabUtils2.UI {
             }
         }
 
-        public static void OpenChapterPanel(Player player, string sid) {
-            Open(player, AreaData.Get(sid) ?? AreaData.Get(0), out OuiHelper_EnterChapterPanel.Start);
+        public static void OpenChapterPanel(Player player, string sid, ChapterPanelTrigger.ReturnToLobbyMode returnToLobbyMode) {
+            Open(player, AreaData.Get(sid) ?? AreaData.Get(0), out OuiHelper_EnterChapterPanel.Start,
+                overworld => new DynData<Overworld>(overworld).Set("returnToLobbyMode", returnToLobbyMode));
         }
 
         public static void OpenJournal(Player player, string levelset) {
             Open(player, AreaData.Areas.FirstOrDefault(area => area.LevelSet == levelset) ?? AreaData.Get(0), out OuiHelper_EnterJournal.Start);
         }
 
-        public static void Open(Player player, AreaData area, out bool opened) {
+        public static void Open(Player player, AreaData area, out bool opened, Action<Overworld> callback = null) {
             opened = false;
 
             if (overworldWrapper?.Scene == Engine.Scene || player.StateMachine.State == Player.StDummy)
@@ -311,6 +313,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
 
             level.Add(overworldWrapper);
             new DynData<Overworld>(overworldWrapper.WrappedScene).Set("collabInGameForcedArea", area);
+            callback?.Invoke(overworldWrapper.WrappedScene);
 
             overworldWrapper.Add(new Coroutine(UpdateRoutine()));
         }


### PR DESCRIPTION
This will come in handy, for example, for using chapter panel triggers to teleport between lobbies: in this case, you don't want the Return to Lobby option to appear (`RemoveReturn`).

If you get from a lobby to a "gym hub", and from the "gym hub" to a gym, you can have a `SetReturnToHere` teleporter followed by a `DoNotChangeReturn` one. This way, Return to Lobby will still return to the lobby.