### PR TITLE
Give Map Swap Trigger a Ahorn plugin and remove flag trigger hook

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -16,3 +16,8 @@ placements.entities.CollabUtils2/MiniHeartDoor.tooltips.requires=Determines the 
 placements.entities.CollabUtils2/MiniHeartDoor.tooltips.startHidden=Whether the door should start hidden and come crashing down when the player approaches.\nWill destroy dash blocks as it crashes down.
 placements.entities.CollabUtils2/MiniHeartDoor.tooltips.levelSet=The heart door will be unlocked by collecting mini hearts in this level set.
 placements.entities.CollabUtils2/MiniHeartDoor.tooltips.color=The color of the door. Also supports hex color codes.
+
+# Map Swap Trigger
+placements.triggers.CollabUtils2/MapSwapTrigger.tooltips.map=The SID (string ID) of the map this trigger will teleport to.
+placements.triggers.CollabUtils2/MapSwapTrigger.tooltips.side=The side (A/B/C) this trigger will teleport to.
+placements.triggers.CollabUtils2/MapSwapTrigger.tooltips.room=The name of the room this trigger will teleport to.

--- a/Ahorn/triggers/mapSwapTrigger.jl
+++ b/Ahorn/triggers/mapSwapTrigger.jl
@@ -1,0 +1,21 @@
+module CollabUtils2MapSwapTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "CollabUtils2/MapSwapTrigger" MapSwapTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    map::String="Celeste/1-ForsakenCity", side::String="Normal", room::String="1")
+
+const placements = Ahorn.PlacementDict(
+    "Map Swap (Collab Utils 2)" => Ahorn.EntityPlacement(
+        MapSwapTrigger,
+        "rectangle",
+    ),
+)
+
+function Ahorn.editingOptions(trigger::MapSwapTrigger)
+    return Dict{String, Any}(
+        "side" => String["Normal", "BSide", "CSide"]
+    )
+end
+
+end

--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -21,7 +21,6 @@ namespace Celeste.Mod.CollabUtils2 {
         }
 
         public override void Load() {
-            Everest.Events.Level.OnLoadEntity += OnLoadEntity;
             InGameOverworldHelper.Load();
             ReturnToLobbyHelper.Load();
             StrawberryHooks.Load();
@@ -29,7 +28,6 @@ namespace Celeste.Mod.CollabUtils2 {
         }
 
         public override void Unload() {
-            Everest.Events.Level.OnLoadEntity -= OnLoadEntity;
             InGameOverworldHelper.Unload();
             ReturnToLobbyHelper.Unload();
             StrawberryHooks.Unload();
@@ -55,36 +53,6 @@ namespace Celeste.Mod.CollabUtils2 {
             base.PrepareMapDataProcessors(context);
 
             context.Add<CollabMapDataProcessor>();
-        }
-
-        private static bool OnLoadEntity(Level level, LevelData levelData, Vector2 offset, EntityData entityData) {
-            // Allow using the Everest flag trigger with custom "commands" because I don't have time for Ahorn plugins. -ade
-            if (entityData.Name == "everest/flagTrigger" && entityData.Attr("flag").StartsWith("/collab2:")) {
-                string[] args = entityData.Attr("flag").Substring(9).Split(' ');
-                switch (args[0]) {
-                    case "mapswap":
-                        level.Add(new MapSwapTrigger(entityData, offset) {
-                            map = args.ElementAtOrDefault(1),
-                            side = args.ElementAtOrDefault(2),
-                            room = args.ElementAtOrDefault(3)
-                        });
-                        return true;
-
-                    case "chapter":
-                        level.Add(new ChapterPanelTrigger(entityData, offset) {
-                            map = args.ElementAtOrDefault(1)
-                        });
-                        return true;
-
-                    case "journal":
-                        level.Add(new JournalTrigger(entityData, offset) {
-                            levelset = args.ElementAtOrDefault(1)
-                        });
-                        return true;
-                }
-            }
-
-            return false;
         }
     }
 }


### PR DESCRIPTION
Map swap trigger will certainly be used for quick teleportation within gyms, as an alternative to the instant teleport trigger from Celsius. (+ teleport between bins might be needed.)