### PR TITLE
Pause file timer when returning to lobby until the player does something

### DIFF
--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -25,6 +25,7 @@ namespace Celeste.Mod.CollabUtils2 {
             ReturnToLobbyHelper.Load();
             StrawberryHooks.Load();
             MiniHeartDoor.Load();
+            LobbyHelper.Load();
         }
 
         public override void Unload() {
@@ -32,6 +33,7 @@ namespace Celeste.Mod.CollabUtils2 {
             ReturnToLobbyHelper.Unload();
             StrawberryHooks.Unload();
             MiniHeartDoor.Unload();
+            LobbyHelper.Unload();
         }
 
         public override void LoadContent(bool firstLoad) {

--- a/UI/LevelExitToLobby.cs
+++ b/UI/LevelExitToLobby.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Xna.Framework;
+﻿using FMOD.Studio;
+using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod.Utils;
 using System.Collections;
 
 namespace Celeste.Mod.CollabUtils2.UI {
@@ -49,6 +51,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             session.StartedFromBeginning = false;
             session.Level = targetRoom;
             session.RespawnPoint = targetSpawnPoint;
+            new DynData<Session>(session)["pauseTimerUntilAction"] = true;
             LevelEnter.Go(session, false);
         }
     }


### PR DESCRIPTION
Requested on Discord.

The intention is allowing speedrunners to take a break in between maps (like in chapter select during vanilla runs), but still having lobbies count towards the file timer.