### PR TITLE
Register crystal hearts/poems for the lobby when registering one for the matching heart side

### DIFF
--- a/LobbyHelper.cs
+++ b/LobbyHelper.cs
@@ -1,5 +1,7 @@
-﻿using MonoMod.Utils;
+﻿using Monocle;
+using MonoMod.Utils;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Celeste.Mod.CollabUtils2 {
@@ -19,14 +21,43 @@ namespace Celeste.Mod.CollabUtils2 {
             return null;
         }
 
+        /// <summary>
+        /// Returns the SID of the lobby corresponding to this level set.
+        /// </summary>
+        /// <param name="levelSet">The level set name</param>
+        /// <returns>The SID of the lobby for this level set, or null if the given level set does not belong to a collab or has no matching lobby.</returns>
+        public static string GetLobbyForLevelSet(string levelSet) {
+            if (levelSet.StartsWith("SpringCollab2020/")) {
+                // build the expected lobby name (SpringCollab2020/1-Beginner => SpringCollab2020/0-Lobbies/1-Beginner) and check it exists before returning it.
+                string expectedLobbyName = "SpringCollab2020/0-Lobbies/" + levelSet.Substring("SpringCollab2020/".Length);
+                if (AreaData.Get(expectedLobbyName) != null) {
+                    return expectedLobbyName;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Check if the given SID matches a collab heart side level.
+        /// </summary>
+        /// <param name="sid">The SID for a map</param>
+        /// <returns>true if this is a collab heart side, false otherwise.</returns>
+        public static bool IsHeartSide(string sid) {
+            return sid.StartsWith("SpringCollab2020/") && sid.EndsWith("/ZZ-HeartSide");
+        }
+
         public static void Load() {
             On.Celeste.Level.LoadLevel += onLoadLevel;
             On.Celeste.Player.Update += onPlayerUpdate;
+            On.Celeste.SaveData.RegisterHeartGem += onRegisterHeartGem;
+            On.Celeste.SaveData.RegisterPoemEntry += onRegisterPoemEntry;
         }
 
         public static void Unload() {
             On.Celeste.Level.LoadLevel -= onLoadLevel;
             On.Celeste.Player.Update -= onPlayerUpdate;
+            On.Celeste.SaveData.RegisterHeartGem -= onRegisterHeartGem;
+            On.Celeste.SaveData.RegisterPoemEntry -= onRegisterPoemEntry;
         }
 
         public static void OnSessionCreated() {
@@ -64,6 +95,36 @@ namespace Celeste.Mod.CollabUtils2 {
                 self.SceneAs<Level>().TimerStopped = false;
                 unpauseTimerOnNextAction = false;
             }
+        }
+
+        private static void onRegisterHeartGem(On.Celeste.SaveData.orig_RegisterHeartGem orig, SaveData self, AreaKey area) {
+            orig(self, area);
+
+            if (IsHeartSide(area.GetSID())) {
+                string lobby = GetLobbyForLevelSet(area.GetLevelSet());
+                if (lobby != null) {
+                    // register the heart gem for the lobby as well.
+                    self.RegisterHeartGem(AreaData.Get(lobby).ToKey());
+                }
+            }
+        }
+
+        private static bool onRegisterPoemEntry(On.Celeste.SaveData.orig_RegisterPoemEntry orig, SaveData self, string id) {
+            bool result = orig(self, id);
+
+            AreaKey currentArea = (Engine.Scene as Level)?.Session?.Area ?? AreaKey.Default;
+            if (IsHeartSide(currentArea.GetSID())) {
+                string lobby = GetLobbyForLevelSet(currentArea.GetLevelSet());
+                if (lobby != null) {
+                    // register the poem for the lobby level set as well.
+                    List<string> levelSetPoem = self.GetLevelSetStatsFor(AreaData.Get(lobby).GetLevelSet()).Poem;
+                    if (!levelSetPoem.Contains(id)) {
+                        levelSetPoem.Add(id);
+                    }
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/UI/OuiJournalCollabProgress.cs
+++ b/UI/OuiJournalCollabProgress.cs
@@ -47,7 +47,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             foreach (AreaStats item in SaveData.Instance.Areas_Safe) {
                 AreaData areaData = AreaData.Get(item.ID_Safe);
                 if (!areaData.Interlude_Safe) {
-                    if (areaData.GetSID().StartsWith("SpringCollab2020/") && areaData.GetSID().EndsWith("/ZZ-HeartSide")) {
+                    if (LobbyHelper.IsHeartSide(areaData.GetSID())) {
                         if (allMapsDone) {
                             // add a separator, like the one between regular maps and Farewell
                             currentPage.table.AddRow();


### PR DESCRIPTION
This covers part of #28.

- When you collect a crystal heart for `SpringCollab2020/1-Beginner/ZZ-HeartSide`, register a heart for `SpringCollab2020/0-Lobbies/1-Beginner` as well.
- When you register a poem while in `SpringCollab2020/1-Beginner/ZZ-HeartSide`, add the same poem to the `SpringCollab2020/0-Lobbies` level set.

This way, the overworld shows the heart and the poem "naturally" without us having to force it to.