### PR TITLE
Add a confirm message for returning to lobby

### DIFF
--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -4,6 +4,8 @@ modoptions_collab_title= Collab Utils 2
 collabutils2_returntolobby= Return to Lobby
 collabutils2_restartspeedberry= Restart Speed Berry
 
+collabutils2_returntolobby_confirm_title= RETURN TO LOBBY?
+
 collabutils2_speedberry_gold= Gold:
 collabutils2_speedberry_silver= Silver:
 collabutils2_speedberry_bronze= Bronze:

--- a/Dialog/French.txt
+++ b/Dialog/French.txt
@@ -4,6 +4,8 @@ modoptions_collab_title= Collab Utils 2
 collabutils2_returntolobby= Retour au lobby
 collabutils2_restartspeedberry= Redémarrer la fraise speedrun
 
+collabutils2_returntolobby_confirm_title= RETOURNER AU LOBBY ?
+
 collabutils2_speedberry_gold= Or :
 collabutils2_speedberry_silver= Argent :
 collabutils2_speedberry_bronze= Bronze :


### PR DESCRIPTION
The code is very similar to vanilla code for the "return to map" submenu, but doesn't show any hints ("you'll restart from latest checkpoint" or "you can hit R to quick restart"):
![image](https://cdn.discordapp.com/attachments/663496421663834112/733065793167687731/unknown.png)