### PR TITLE
Golden Berry Player Respawn Point: respawn point for silver/speed/golden berry resets

### DIFF
--- a/Ahorn/entities/goldenBerrySpawnPoint.jl
+++ b/Ahorn/entities/goldenBerrySpawnPoint.jl
@@ -1,0 +1,24 @@
+﻿module CollabUtils2GoldenBerryPlayerRespawnPoint
+
+using ..Ahorn, Maple
+
+@mapdef Entity "CollabUtils2/GoldenBerryPlayerRespawnPoint" GoldenBerryPlayerRespawnPoint(x::Integer, y::Integer)
+
+const placements = Ahorn.PlacementDict(
+    "Golden Berry Player Respawn Point (Collab Utils 2)" => Ahorn.EntityPlacement(
+        GoldenBerryPlayerRespawnPoint
+    )
+)
+
+const sprite = "characters/player/sitDown00"
+const tint = (0.8, 0.6, 0.1, 0.75)
+
+function Ahorn.selection(entity::GoldenBerryPlayerRespawnPoint)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.getSpriteRectangle(sprite, x, y, jx=0.5, jy=1.0)
+end
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::GoldenBerryPlayerRespawnPoint) = Ahorn.drawSprite(ctx, sprite, 0, 0, jx=0.5, jy=1.0, tint=tint)
+
+end

--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -31,6 +31,7 @@ namespace Celeste.Mod.CollabUtils2 {
             SpeedBerryPBInChapterPanel.Load();
             JournalTrigger.Load();
             CustomCrystalHeartHelper.Load();
+            GoldenBerryPlayerRespawnPoint.Load();
         }
 
         public override void Unload() {
@@ -43,6 +44,7 @@ namespace Celeste.Mod.CollabUtils2 {
             SpeedBerryPBInChapterPanel.Unload();
             JournalTrigger.Unload();
             CustomCrystalHeartHelper.Unload();
+            GoldenBerryPlayerRespawnPoint.Unload();
         }
 
         public override void LoadContent(bool firstLoad) {

--- a/Entities/GoldenBerryPlayerRespawnPoint.cs
+++ b/Entities/GoldenBerryPlayerRespawnPoint.cs
@@ -1,0 +1,31 @@
+﻿using Monocle;
+using MonoMod.Utils;
+using System.Linq;
+
+namespace Celeste.Mod.CollabUtils2.Entities {
+    // no [CustomEntity]: this is added in the map as an entity, but isn't loaded in as one in LoadLevel.
+    class GoldenBerryPlayerRespawnPoint {
+        public static void Load() {
+            On.Celeste.Session.Restart += onSessionRestart;
+        }
+
+        public static void Unload() {
+            On.Celeste.Session.Restart -= onSessionRestart;
+        }
+
+        private static Session onSessionRestart(On.Celeste.Session.orig_Restart orig, Session self, string intoLevel) {
+            Session restartSession = orig(self, intoLevel);
+
+            if (intoLevel != null && Engine.Scene is LevelExit exit && new DynData<LevelExit>(exit).Get<LevelExit.Mode>("mode") == LevelExit.Mode.GoldenBerryRestart) {
+                // we are doing a golden berry restart! look for a golden berry player respawn point.
+                LevelData levelData = restartSession.MapData.Levels.Find(level => level.Name == intoLevel);
+                EntityData goldenRespawn = levelData.Entities.FirstOrDefault(entityData => entityData.Name == "CollabUtils2/GoldenBerryPlayerRespawnPoint");
+                if (goldenRespawn != null) {
+                    restartSession.RespawnPoint = goldenRespawn.Position;
+                }
+            }
+
+            return restartSession;
+        }
+    }
+}


### PR DESCRIPTION
This is intended as a convenience for speedrunners / people attempting silver berries when the initial spawn point is far away from the berries.

Here is how it looks like in Ahorn:

![image](https://user-images.githubusercontent.com/52103563/89826241-3faa0980-db56-11ea-90a6-b1269c4a0cf1.png)

This is an entity on the Ahorn/level data side, but not in-game: this is only checked for when the session is reset after dying with a "golden berry" (which is technically what happens for silver and speed berries as well).