### PR TITLE
Loosen accessibility modifiers and use provided constant values

### DIFF
--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -48,7 +48,7 @@ namespace Celeste.Mod.CollabUtils2 {
 
             Everest.Content.OnUpdate += onModAssetUpdate;
 
-            hookOrigSessionCtor = new Hook(typeof(Session).GetMethod("orig_ctor"), typeof(CollabModule).GetMethod("onNewSession", BindingFlags.NonPublic | BindingFlags.Static));
+            hookOrigSessionCtor = new Hook(typeof(Session).GetMethod("orig_ctor"), typeof(CollabModule).GetMethod(nameof(onNewSession), BindingFlags.NonPublic | BindingFlags.Static));
         }
 
         public override void Unload() {

--- a/CustomCrystalHeartHelper.cs
+++ b/CustomCrystalHeartHelper.cs
@@ -7,12 +7,12 @@ using System.Text.RegularExpressions;
 namespace Celeste.Mod.CollabUtils2 {
     class CustomCrystalHeartHelper {
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.HeartGem.Awake += customizeParticles;
             On.Celeste.Poem.ctor += customizePoemDisplay;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.HeartGem.Awake -= customizeParticles;
             On.Celeste.Poem.ctor -= customizePoemDisplay;
         }

--- a/Entities/AbstractMiniHeart.cs
+++ b/Entities/AbstractMiniHeart.cs
@@ -3,7 +3,7 @@ using Monocle;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     // This is all code in common between mini hearts and fake mini hearts.
-    abstract class AbstractMiniHeart : Entity {
+    public abstract class AbstractMiniHeart : Entity {
         protected static readonly int[] animationFrames = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
 
         protected Sprite sprite;

--- a/Entities/FakeMiniHeart.cs
+++ b/Entities/FakeMiniHeart.cs
@@ -4,7 +4,7 @@ using Monocle;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     [CustomEntity("CollabUtils2/FakeMiniHeart")]
-    class FakeMiniHeart : AbstractMiniHeart {
+    public class FakeMiniHeart : AbstractMiniHeart {
         private float respawnTimer;
 
         public FakeMiniHeart(EntityData data, Vector2 position, EntityID gid)

--- a/Entities/GoldenBerryPlayerRespawnPoint.cs
+++ b/Entities/GoldenBerryPlayerRespawnPoint.cs
@@ -5,11 +5,11 @@ using System.Linq;
 namespace Celeste.Mod.CollabUtils2.Entities {
     // no [CustomEntity]: this is added in the map as an entity, but isn't loaded in as one in LoadLevel.
     class GoldenBerryPlayerRespawnPoint {
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.Session.Restart += onSessionRestart;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.Session.Restart -= onSessionRestart;
         }
 

--- a/Entities/HoloRainbowBerry.cs
+++ b/Entities/HoloRainbowBerry.cs
@@ -69,7 +69,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 scene.Add(counterText);
             }
 
-            scene.Add(Particles = new ParticleSystem(-50000, 800));
+            scene.Add(Particles = new ParticleSystem(Depths.FGParticles, 800));
             Particles.Tag = Tag;
         }
 

--- a/Entities/HoloRainbowBerry.cs
+++ b/Entities/HoloRainbowBerry.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
 
-    class HoloRainbowBerry : Entity {
+    public class HoloRainbowBerry : Entity {
         private float wobble = 0f;
         private Sprite sprite;
         private Sprite desaturatedSprite;

--- a/Entities/MiniHeart.cs
+++ b/Entities/MiniHeart.cs
@@ -52,12 +52,12 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             white.CenterOrigin();
 
             // slow down time, visual effects
-            Depth = -2000000;
+            Depth = Depths.FormationSequences;
             yield return null;
             Celeste.Freeze(0.2f);
             yield return null;
             Engine.TimeRate = 0.5f;
-            player.Depth = -2000000;
+            player.Depth = Depths.FormationSequences;
             for (int i = 0; i < 10; i++) {
                 Scene.Add(new AbsorbOrb(Position));
             }

--- a/Entities/MiniHeart.cs
+++ b/Entities/MiniHeart.cs
@@ -9,7 +9,7 @@ using System.Collections.ObjectModel;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     [CustomEntity("CollabUtils2/MiniHeart")]
-    class MiniHeart : AbstractMiniHeart {
+    public class MiniHeart : AbstractMiniHeart {
         private Sprite white;
         private bool inCollectAnimation = false;
 

--- a/Entities/MiniHeartDoor.cs
+++ b/Entities/MiniHeartDoor.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     [CustomEntity("CollabUtils2/MiniHeartDoor")]
-    class MiniHeartDoor : HeartGemDoor {
+    public class MiniHeartDoor : HeartGemDoor {
         private static Hook hookOnHeartCount;
         private static ILHook hookOnDoorRoutine;
 
@@ -24,14 +24,14 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             { "grandmaster", "650091" }
         };
 
-        public static void Load() {
+        internal static void Load() {
             hookOnHeartCount = new Hook(typeof(HeartGemDoor).GetMethod("get_HeartGems"),
                 typeof(MiniHeartDoor).GetMethod("getCollectedHeartGems", BindingFlags.NonPublic | BindingFlags.Static));
             hookOnDoorRoutine = HookHelper.HookCoroutine("Celeste.HeartGemDoor", "Routine", modDoorRoutine);
             IL.Celeste.HeartGemDoor.DrawInterior += modDoorColor;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             hookOnHeartCount?.Dispose();
             hookOnDoorRoutine?.Dispose();
             IL.Celeste.HeartGemDoor.DrawInterior -= modDoorColor;

--- a/Entities/MiniHeartDoor.cs
+++ b/Entities/MiniHeartDoor.cs
@@ -26,7 +26,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
 
         internal static void Load() {
             hookOnHeartCount = new Hook(typeof(HeartGemDoor).GetMethod("get_HeartGems"),
-                typeof(MiniHeartDoor).GetMethod("getCollectedHeartGems", BindingFlags.NonPublic | BindingFlags.Static));
+                typeof(MiniHeartDoor).GetMethod(nameof(getCollectedHeartGems), BindingFlags.NonPublic | BindingFlags.Static));
             hookOnDoorRoutine = HookHelper.HookCoroutine("Celeste.HeartGemDoor", "Routine", modDoorRoutine);
             IL.Celeste.HeartGemDoor.DrawInterior += modDoorColor;
         }

--- a/Entities/MiniHeartDoorUnlockCutscene.cs
+++ b/Entities/MiniHeartDoorUnlockCutscene.cs
@@ -21,11 +21,11 @@ namespace Celeste.Mod.CollabUtils2.Entities {
 
         private IEnumerator Cutscene(Level level) {
             // wait for the respawn animation to be over.
-            while (player.StateMachine.State != 0) {
+            while (player.StateMachine.State != Player.StNormal) {
                 yield return null;
             }
 
-            player.StateMachine.State = 11;
+            player.StateMachine.State = Player.StDummy;
 
             yield return 0.5f;
 
@@ -50,7 +50,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         }
 
         public override void OnEnd(Level level) {
-            player.StateMachine.State = 0;
+            player.StateMachine.State = Player.StNormal;
             player.ForceCameraUpdate = false;
 
             if (WasSkipped) {

--- a/Entities/RainbowBerry.cs
+++ b/Entities/RainbowBerry.cs
@@ -10,7 +10,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
     /// </summary>
     [CustomEntity("CollabUtils2/RainbowBerry")]
     [RegisterStrawberry(tracked: false, blocksCollection: false)]
-    class RainbowBerry : Strawberry {
+    public class RainbowBerry : Strawberry {
         private string levelSet;
 
         internal HoloRainbowBerry HologramForCutscene;

--- a/Entities/RainbowBerryPerfectEffect.cs
+++ b/Entities/RainbowBerryPerfectEffect.cs
@@ -8,7 +8,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             : base(position) {
 
             Sprite sprite;
-            Depth = -1000000;
+            Depth = Depths.Top;
             Add(sprite = GFX.SpriteBank.Create("CollabUtils2_perfectAnimation"));
             sprite.OnLastFrame = delegate {
                 RemoveSelf();

--- a/Entities/RainbowBerryPerfectEffect.cs
+++ b/Entities/RainbowBerryPerfectEffect.cs
@@ -2,7 +2,7 @@
 using Monocle;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
-    class RainbowBerryPerfectEffect : Entity {
+    public class RainbowBerryPerfectEffect : Entity {
 
         public RainbowBerryPerfectEffect(Vector2 position)
             : base(position) {

--- a/Entities/RainbowBerryUnlockCutscene.cs
+++ b/Entities/RainbowBerryUnlockCutscene.cs
@@ -32,7 +32,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 while (!player.InControl) {
                     yield return null;
                 }
-                player.StateMachine.State = 11;
+                player.StateMachine.State = Player.StDummy;
             }
 
             // start animation, mute sound
@@ -52,10 +52,10 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             }
 
             // freeze the level after a bit
-            Depth = -2000003;
-            strawberry.Depth = -2000002;
-            holoBerry.Depth = -2000002;
-            holoBerry.Particles.Depth = -2000002;
+            Depth = Depths.FormationSequences - 3;
+            strawberry.Depth = Depths.FormationSequences - 2;
+            holoBerry.Depth = -Depths.FormationSequences - 2;
+            holoBerry.Particles.Depth = Depths.FormationSequences - 2;
             strawberry.AddTag(Tags.FrozenUpdate);
             yield return 0.35f;
             Tag = Tags.FrozenUpdate;
@@ -66,13 +66,13 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             level.FormationBackdrop.Alpha = 0.5f;
             level.Displacement.Clear();
             level.Displacement.Enabled = false;
-            Audio.BusPaused("bus:/gameplay_sfx/ambience", true);
-            Audio.BusPaused("bus:/gameplay_sfx/char", true);
-            Audio.BusPaused("bus:/gameplay_sfx/game/general/yes_pause", true);
-            Audio.BusPaused("bus:/gameplay_sfx/game/chapters", true);
+            Audio.BusPaused(Buses.AMBIENCE, true);
+            Audio.BusPaused(Buses.CHAR, true);
+            Audio.BusPaused(Buses.YES_PAUSE, true);
+            Audio.BusPaused(Buses.CHAPTERS, true);
             yield return 0.1f;
 
-            system = new ParticleSystem(-2000002, 50);
+            system = new ParticleSystem(Depths.FormationSequences - 2, 50);
             system.Tag = Tags.FrozenUpdate;
             level.Add(system);
 
@@ -122,7 +122,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             }
             Player player = Scene.Tracker.GetEntity<Player>();
             if (player != null) {
-                player.StateMachine.State = 0;
+                player.StateMachine.State = Player.StNormal;
             }
             level.OnEndOfFrame += delegate {
                 if (WasSkipped) {
@@ -135,7 +135,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                     strawberry.CollectedSeeds();
                     level.Camera.Position = player.CameraTarget;
                 }
-                strawberry.Depth = -100;
+                strawberry.Depth = Depths.Pickups;
                 strawberry.RemoveTag(Tags.FrozenUpdate);
                 level.Frozen = false;
                 level.FormationBackdrop.Display = false;
@@ -145,10 +145,10 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         }
 
         private void endSfx() {
-            Audio.BusPaused("bus:/gameplay_sfx/ambience", false);
-            Audio.BusPaused("bus:/gameplay_sfx/char", false);
-            Audio.BusPaused("bus:/gameplay_sfx/game/general/yes_pause", false);
-            Audio.BusPaused("bus:/gameplay_sfx/game/chapters", false);
+            Audio.BusPaused(Buses.AMBIENCE, false);
+            Audio.BusPaused(Buses.CHAR, false);
+            Audio.BusPaused(Buses.YES_PAUSE, false);
+            Audio.BusPaused(Buses.CHAPTERS, false);
             Audio.ReleaseSnapshot(snapshot);
         }
 

--- a/Entities/SilverBerry.cs
+++ b/Entities/SilverBerry.cs
@@ -9,7 +9,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
     /// </summary>
     [CustomEntity("CollabUtils2/SilverBerry")]
     [RegisterStrawberry(tracked: false, blocksCollection: true)]
-    class SilverBerry : Strawberry {
+    public class SilverBerry : Strawberry {
         private static ParticleType P_SilverGlow;
         private static ParticleType P_OrigGoldGlow;
         private static ParticleType P_SilverGhostGlow;

--- a/Entities/SilverBlock.cs
+++ b/Entities/SilverBlock.cs
@@ -7,11 +7,11 @@ using System;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     [CustomEntity("CollabUtils2/SilverBlock")]
-    class SilverBlock : GoldenBlock {
-        public static void Load() {
+    public class SilverBlock : GoldenBlock {
+        internal static void Load() {
             IL.Celeste.GoldenBlock.ctor_Vector2_float_float += modGoldenBlockConstructor;
         }
-        public static void Unload() {
+        internal static void Unload() {
             IL.Celeste.GoldenBlock.ctor_Vector2_float_float -= modGoldenBlockConstructor;
         }
 

--- a/Entities/SpeedBerry.cs
+++ b/Entities/SpeedBerry.cs
@@ -226,7 +226,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         private class SpeedBerryExplosionAnimation : Entity {
             public SpeedBerryExplosionAnimation(Vector2 position) : base(position) {
                 Add(GFX.SpriteBank.Create("CollabUtils2_speedBerryExplosion"));
-                Depth = -1000000;
+                Depth = Depths.Top;
             }
         }
     }

--- a/Entities/SpeedBerry.cs
+++ b/Entities/SpeedBerry.cs
@@ -37,12 +37,12 @@ namespace Celeste.Mod.CollabUtils2.Entities {
 
         private static bool transitionJustTriggered = false;
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.Level.NextLevel += onTransitionTriggered;
             On.Celeste.Player.OnTransition += onTransitionEnd;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.Level.NextLevel -= onTransitionTriggered;
             On.Celeste.Player.OnTransition -= onTransitionEnd;
         }

--- a/Entities/StrawberryHooks.cs
+++ b/Entities/StrawberryHooks.cs
@@ -22,7 +22,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         private static ILHook collectRoutineHook;
         private static ILHook playerDeathRoutineHook;
 
-        public static void Load() {
+        internal static void Load() {
             IL.Celeste.Strawberry.Added += modStrawberrySprite;
             collectRoutineHook = HookHelper.HookCoroutine("Celeste.Strawberry", "CollectRoutine", modStrawberrySound);
             On.Celeste.Player.Die += onPlayerDie;
@@ -34,7 +34,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             On.Celeste.Level.End += onLevelEnd;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             IL.Celeste.Strawberry.Added -= modStrawberrySprite;
             collectRoutineHook?.Dispose();
             On.Celeste.Player.Die -= onPlayerDie;

--- a/Entities/StrawberryHooks.cs
+++ b/Entities/StrawberryHooks.cs
@@ -166,7 +166,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             SpeedBerry speedBerry = null;
 
             // check if the player is actually going to die first.
-            if (!self.Dead && (evenIfInvincible || !SaveData.Instance.Assists.Invincible) && self.StateMachine.State != 18) {
+            if (!self.Dead && (evenIfInvincible || !SaveData.Instance.Assists.Invincible) && self.StateMachine.State != Player.StReflectionFall) {
                 hasSilver = self.Leader.Followers.Any(follower => follower.Entity is SilverBerry);
                 Follower speedBerryFollower = self.Leader.Followers.Find(follower => follower.Entity is SpeedBerry);
                 if (speedBerryFollower != null) {

--- a/HookHelper.cs
+++ b/HookHelper.cs
@@ -7,7 +7,7 @@ using MonoMod.Utils;
 using Mono.Cecil.Cil;
 
 namespace Celeste.Mod.CollabUtils2 {
-    static class HookHelper {
+    public static class HookHelper {
         /// <summary>
         /// Utility method to patch "coroutine" kinds of methods with IL.
         /// Those methods' code reside in a compiler-generated method, and IL.Celeste.* do not allow manipulating them directly.

--- a/LobbyHelper.cs
+++ b/LobbyHelper.cs
@@ -14,7 +14,7 @@ using System.Linq;
 using System.Reflection;
 
 namespace Celeste.Mod.CollabUtils2 {
-    static class LobbyHelper {
+    public static class LobbyHelper {
 
         private static bool unpauseTimerOnNextAction = false;
 
@@ -36,7 +36,7 @@ namespace Celeste.Mod.CollabUtils2 {
             }
         }
 
-        internal static void LoadCollabIDFile(ModAsset asset) {
+        public static void LoadCollabIDFile(ModAsset asset) {
             string fileContents;
             using (StreamReader reader = new StreamReader(asset.Stream)) {
                 fileContents = reader.ReadToEnd();
@@ -116,7 +116,7 @@ namespace Celeste.Mod.CollabUtils2 {
             return collabNames.Any(collabName => sid.StartsWith($"{collabName}/")) && sid.EndsWith("/ZZ-HeartSide");
         }
 
-        public static void Load() {
+        internal static void Load() {
             // timer pausing when returning to lobby
             On.Celeste.Level.LoadLevel += onLoadLevel;
             On.Celeste.Player.Update += onPlayerUpdate;
@@ -142,7 +142,7 @@ namespace Celeste.Mod.CollabUtils2 {
             hookOnOuiFileSelectSlotGolden = new ILHook(typeof(OuiFileSelectSlot).GetMethod("get_Golden", BindingFlags.NonPublic | BindingFlags.Instance), modSelectSlotCollectedStrawberries);
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.Level.LoadLevel -= onLoadLevel;
             On.Celeste.Player.Update -= onPlayerUpdate;
 

--- a/LobbyHelper.cs
+++ b/LobbyHelper.cs
@@ -122,7 +122,7 @@ namespace Celeste.Mod.CollabUtils2 {
             On.Celeste.Player.Update += onPlayerUpdate;
 
             // hiding collab maps from chapter select
-            hookOnLevelSetSwitch = HookHelper.HookCoroutine("Celeste.Mod.UI.OuiHelper_ChapterSelect_LevelSet", "Enter", modLevelSetSwitch);
+            hookOnLevelSetSwitch = HookHelper.HookCoroutine(typeof(OuiHelper_ChapterSelect_LevelSet).FullName, "Enter", modLevelSetSwitch);
             IL.Celeste.Mod.UI.OuiMapSearch.ReloadItems += modMapSearch;
             IL.Celeste.Mod.UI.OuiMapList.ReloadItems += modMapListReloadItems;
             IL.Celeste.Mod.UI.OuiMapList.CreateMenu += modMapListCreateMenu;

--- a/Triggers/JournalTrigger.cs
+++ b/Triggers/JournalTrigger.cs
@@ -13,11 +13,11 @@ namespace Celeste.Mod.CollabUtils2.Triggers {
     public class JournalTrigger : Trigger {
         private static bool showOnlyDiscovered;
 
-        public static void Load() {
+        internal static void Load() {
             Everest.Events.Journal.OnEnter += onJournalEnter;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             Everest.Events.Journal.OnEnter -= onJournalEnter;
         }
 

--- a/Triggers/MiniHeartDoorUnlockCutsceneTrigger.cs
+++ b/Triggers/MiniHeartDoorUnlockCutsceneTrigger.cs
@@ -13,11 +13,11 @@ namespace Celeste.Mod.CollabUtils2.Triggers {
     [Tracked]
     class MiniHeartDoorUnlockCutsceneTrigger : Trigger {
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.Level.AssistMode += modAssistModeOptions;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.Level.AssistMode -= modAssistModeOptions;
         }
 

--- a/Triggers/SpeedBerryCollectTrigger.cs
+++ b/Triggers/SpeedBerryCollectTrigger.cs
@@ -5,7 +5,7 @@ using Monocle;
 namespace Celeste.Mod.CollabUtils2.Triggers {
     [CustomEntity("CollabUtils2/SpeedBerryCollectTrigger")]
     [Tracked]
-    class SpeedBerryCollectTrigger : Trigger {
+    public class SpeedBerryCollectTrigger : Trigger {
         public SpeedBerryCollectTrigger(EntityData data, Vector2 offset) : base(data, offset) { }
     }
 }

--- a/UI/AreaCompleteInfoInLevel.cs
+++ b/UI/AreaCompleteInfoInLevel.cs
@@ -11,7 +11,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
     /// <summary>
     /// A standalone entity displaying the area complete stats directly in a level.
     /// </summary>
-    class AreaCompleteInfoInLevel : Entity {
+    public class AreaCompleteInfoInLevel : Entity {
         private static FieldInfo areaCompleteVersionFull = typeof(AreaComplete).GetField("versionFull", BindingFlags.NonPublic | BindingFlags.Static);
 
         private static ILHook versionNumberAndVariantsHook;
@@ -25,13 +25,13 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private string chapterSpeedrunText = Dialog.Get("OPTIONS_SPEEDRUN_CHAPTER") + ":";
         private string version = Celeste.Instance.Version.ToString();
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.AreaComplete.InitAreaCompleteInfoForEverest += onAreaCompleteInit;
             On.Celeste.AreaComplete.DisposeAreaCompleteInfoForEverest += onAreaCompleteDispose;
             versionNumberAndVariantsHook = new ILHook(typeof(AreaComplete).GetMethod("orig_VersionNumberAndVariants"), shiftVersionNumberAndVariantsUp);
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.AreaComplete.InitAreaCompleteInfoForEverest -= onAreaCompleteInit;
             On.Celeste.AreaComplete.DisposeAreaCompleteInfoForEverest -= onAreaCompleteDispose;
             versionNumberAndVariantsHook?.Dispose();

--- a/UI/InGameOverworldHelper.cs
+++ b/UI/InGameOverworldHelper.cs
@@ -55,11 +55,11 @@ namespace Celeste.Mod.CollabUtils2.UI {
 
                 altSidesHelperHooks.Add(new Hook(
                     altSidesHelperModule.GetMethod("ResetCrystalHeart", BindingFlags.NonPublic | BindingFlags.Static),
-                    typeof(InGameOverworldHelper).GetMethod("resetCrystalHeartAfterAltSidesHelper", BindingFlags.NonPublic | BindingFlags.Static)));
+                    typeof(InGameOverworldHelper).GetMethod(nameof(resetCrystalHeartAfterAltSidesHelper), BindingFlags.NonPublic | BindingFlags.Static)));
 
                 altSidesHelperHooks.Add(new Hook(
                     altSidesHelperModule.GetMethod("CustomizeCrystalHeart", BindingFlags.NonPublic | BindingFlags.Static),
-                    typeof(InGameOverworldHelper).GetMethod("customizeCrystalHeartAfterAltSidesHelper", BindingFlags.NonPublic | BindingFlags.Static)));
+                    typeof(InGameOverworldHelper).GetMethod(nameof(customizeCrystalHeartAfterAltSidesHelper), BindingFlags.NonPublic | BindingFlags.Static)));
             }
         }
 

--- a/UI/InGameOverworldHelper.cs
+++ b/UI/InGameOverworldHelper.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
 
         private static List<Hook> altSidesHelperHooks = new List<Hook>();
 
-        public static void Load() {
+        internal static void Load() {
             Everest.Events.Level.OnPause += OnPause;
             On.Celeste.Audio.SetMusic += OnSetMusic;
             On.Celeste.Audio.SetAmbience += OnSetAmbience;
@@ -63,7 +63,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             }
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             Everest.Events.Level.OnPause -= OnPause;
             On.Celeste.Audio.SetMusic -= OnSetMusic;
             On.Celeste.Audio.SetAmbience -= OnSetAmbience;

--- a/UI/OuiJournalLobbyMap.cs
+++ b/UI/OuiJournalLobbyMap.cs
@@ -2,7 +2,7 @@
 using Monocle;
 
 namespace Celeste.Mod.CollabUtils2.UI {
-    class OuiJournalLobbyMap : OuiJournalPage {
+    public class OuiJournalLobbyMap : OuiJournalPage {
         private MTexture mapImage;
 
         public OuiJournalLobbyMap(OuiJournal journal, MTexture mapImage) : base(journal) {

--- a/UI/ReturnToLobbyHelper.cs
+++ b/UI/ReturnToLobbyHelper.cs
@@ -17,7 +17,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private static Vector2 temporarySpawnPointHolder;
         private static bool temporarySaveAllowedHolder;
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.OuiChapterPanel.StartRoutine += modChapterPanelStartRoutine;
             Everest.Events.Level.OnCreatePauseMenuButtons += onCreatePauseMenuButtons;
             On.Celeste.LevelExit.ctor += onLevelExitConstructor;
@@ -30,7 +30,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             }
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.OuiChapterPanel.StartRoutine -= modChapterPanelStartRoutine;
             Everest.Events.Level.OnCreatePauseMenuButtons -= onCreatePauseMenuButtons;
             On.Celeste.LevelExit.ctor -= onLevelExitConstructor;

--- a/UI/ReturnToLobbyHelper.cs
+++ b/UI/ReturnToLobbyHelper.cs
@@ -172,7 +172,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
                     Engine.TimeRate = 1f;
                     menu.Focused = false;
                     Audio.SetMusic(null);
-                    Audio.BusStopAll("bus:/gameplay_sfx", immediate: true);
+                    Audio.BusStopAll(Buses.GAMEPLAY, immediate: true);
 
                     // add a death, like vanilla Save & Quit
                     level.Session.InArea = true;
@@ -221,7 +221,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 Engine.TimeRate = 1f;
                 menu.Focused = false;
                 Audio.SetMusic(null);
-                Audio.BusStopAll("bus:/gameplay_sfx", immediate: true);
+                Audio.BusStopAll(Buses.GAMEPLAY, immediate: true);
 
                 level.DoScreenWipe(wipeIn: false, () => {
                     Engine.Scene = new LevelExitToLobby(LevelExit.Mode.GiveUp, level.Session);

--- a/UI/SpeedBerryPBInChapterPanel.cs
+++ b/UI/SpeedBerryPBInChapterPanel.cs
@@ -10,14 +10,14 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private static SpeedBerryPBDisplay speedBerryPBDisplay;
         private static Vector2 speedBerryPBOffset;
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.OuiChapterPanel.ctor += modOuiChapterPanelConstructor;
             IL.Celeste.OuiChapterPanel.Render += modOuiChapterPanelRender;
             On.Celeste.OuiChapterPanel.UpdateStats += modOuiChapterPanelUpdateStats;
             IL.Celeste.OuiChapterPanel.SetStatsPosition += modOuiChapterPanelSetStatsPosition;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.OuiChapterPanel.ctor -= modOuiChapterPanelConstructor;
             IL.Celeste.OuiChapterPanel.Render -= modOuiChapterPanelRender;
             On.Celeste.OuiChapterPanel.UpdateStats -= modOuiChapterPanelUpdateStats;

--- a/UI/SpeedBerryTimerDisplay.cs
+++ b/UI/SpeedBerryTimerDisplay.cs
@@ -8,11 +8,11 @@ namespace Celeste.Mod.CollabUtils2.UI {
     [Tracked]
     public class SpeedBerryTimerDisplay : Entity {
 
-        public static void Load() {
+        internal static void Load() {
             On.Celeste.TotalStrawberriesDisplay.Update += onTotalStrawberriesDisplayUpdate;
         }
 
-        public static void Unload() {
+        internal static void Unload() {
             On.Celeste.TotalStrawberriesDisplay.Update -= onTotalStrawberriesDisplayUpdate;
         }
 

--- a/UI/SpeedBerryTimerDisplay.cs
+++ b/UI/SpeedBerryTimerDisplay.cs
@@ -176,7 +176,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 }
             }
 
-            Depth = startChapterTimer == -1 ? 100 : -100;
+            Depth = startChapterTimer == -1 ? Depths.TheoCrystal : Depths.Pickups;
 
             base.Update();
         }


### PR DESCRIPTION
- Loosen accessibility modifiers for all types that could be used by other mods
- Restrict `Load` and `Unload` methods to `internal`
- Use constant values provided by Celeste (`Depths`, `Buses`) where appropriate
- Use `nameof` expression for private/internal method names in hooks