### PR TITLE
Layout changes

### DIFF
--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -828,6 +828,8 @@ namespace Celeste.Mod.CollabUtils2.UI {
             focused = false;
             const float wipeDuration = 0.5f;
 
+            Audio.Play("event:/game/04_cliffside/snowball_spawn");
+
             void onComplete() {
                 closeScreen(true);
                 if (warp.SID != level.Session.Area.SID) {


### PR DESCRIPTION
* Adjusts map viewport and font sizes to prevent warp text overlapping icons if they're very low.
* Adds the snowball sound for warping.
* Ensures that warps are sorted using natural ordering so that `2` comes before `10`.