### PR TITLE
Various lobby map changes

### DIFF
--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -29,6 +29,8 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private ByteArray2D visitedTiles;
         private LobbyVisitManager visitManager;
         private int heartCount;
+        private int initialLobbyIndex;
+        private int initialWarpIndex;
 
         // resources
         private Texture2D mapTexture;
@@ -200,9 +202,14 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 var close = false;
                 var warpIndex = selectedWarpIndexes[selectedLobbyIndex];
                 if (Input.MenuConfirm.Pressed && warpIndex >= 0 && warpIndex < activeWarps.Count) {
-                    var warp = activeWarps[warpIndex];
-                    confirmWiggler.Start();
-                    teleportToWarp(warp);
+                    if (selectedLobbyIndex == initialLobbyIndex && warpIndex == initialWarpIndex) {
+                        // confirming on the initial warp just closes the screen
+                        close = true;
+                    } else {
+                        var warp = activeWarps[warpIndex];
+                        confirmWiggler.Start();
+                        teleportToWarp(warp);
+                    }
                 } else if (Input.MenuCancel.Pressed) {
                     close = true;
                 } else if (Input.ESC.Pressed) {
@@ -387,6 +394,10 @@ namespace Celeste.Mod.CollabUtils2.UI {
                         selectedWarpIndexes[selectedLobbyIndex] = i;
                     }
                 }
+
+                // keep track of where we started
+                initialLobbyIndex = selectedLobbyIndex;
+                initialWarpIndex = selectedWarpIndexes[selectedLobbyIndex];
             }
 
             var warpIndex = selectedWarpIndexes[selectedLobbyIndex];


### PR DESCRIPTION
Some changes requested through SJ reports:

* Just close the map UI if warping to the current bench rather than reloading the level
* Hide lobbies from the map where no warps have been activated
* Hide the rainbow berry if no silvers have been collected for that lobby