### PR TITLE
Add refill sound when breaking a fake mini heart

### DIFF
--- a/Ahorn/entities/miniHeart.jl
+++ b/Ahorn/entities/miniHeart.jl
@@ -3,7 +3,7 @@ module CollabUtils2MiniHeart
 using ..Ahorn, Maple
 
 @mapdef Entity "CollabUtils2/MiniHeart" MiniHeart(x::Integer, y::Integer, sprite::String="beginner", refillDash::Bool=true, requireDashToBreak::Bool=true, noGhostSprite::Bool=false, particleColor::String="", playPulseSound::Bool=true)
-@mapdef Entity "CollabUtils2/FakeMiniHeart" FakeMiniHeart(x::Integer, y::Integer, sprite::String="beginner", refillDash::Bool=true, requireDashToBreak::Bool=true, noGhostSprite::Bool=false, particleColor::String="", playPulseSound::Bool=true)
+@mapdef Entity "CollabUtils2/FakeMiniHeart" FakeMiniHeart(x::Integer, y::Integer, sprite::String="beginner", refillDash::Bool=true, requireDashToBreak::Bool=true, noGhostSprite::Bool=false, particleColor::String="", playPulseSound::Bool=true, playBreakSound::Bool=false)
 
 heartUnion = Union{MiniHeart, FakeMiniHeart}
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -24,6 +24,7 @@ placements.entities.CollabUtils2/FakeMiniHeart.tooltips.requireDashToBreak=Wheth
 placements.entities.CollabUtils2/FakeMiniHeart.tooltips.noGhostSprite=If checked, the heart will never use the "ghost" sprite even when already collected.
 placements.entities.CollabUtils2/FakeMiniHeart.tooltips.particleColor=The color of the particles emitted by the fake mini heart. Leave empty to use default colors.
 placements.entities.CollabUtils2/FakeMiniHeart.tooltips.playPulseSound=Whether the heart should play a sound along with its pulse.
+placements.entities.CollabUtils2/FakeMiniHeart.tooltips.playBreakSound=Whether the heart should play a refill sound when broken.
 
 # Rainbow Berry
 placements.entities.CollabUtils2/RainbowBerry.tooltips.levelSet=The rainbow berry will only spawn if all silver berries in this level set have been collected.

--- a/Entities/FakeMiniHeart.cs
+++ b/Entities/FakeMiniHeart.cs
@@ -38,6 +38,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 SceneAs<Level>().Shake();
                 SlashFx.Burst(Position, angle);
                 player?.RefillDash();
+                Audio.Play("event:/game/general/diamond_touch", Position);
             }
         }
     }

--- a/Entities/FakeMiniHeart.cs
+++ b/Entities/FakeMiniHeart.cs
@@ -6,9 +6,12 @@ namespace Celeste.Mod.CollabUtils2.Entities {
     [CustomEntity("CollabUtils2/FakeMiniHeart")]
     public class FakeMiniHeart : AbstractMiniHeart {
         private float respawnTimer;
+        private bool soundOnDashed;
 
         public FakeMiniHeart(EntityData data, Vector2 position, EntityID gid)
-            : base(data, position, gid) { }
+            : base(data, position, gid) {
+            soundOnDashed = data.Bool("playBreakSound", false);
+        }
 
         public override void Update() {
             base.Update();
@@ -38,7 +41,9 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 SceneAs<Level>().Shake();
                 SlashFx.Burst(Position, angle);
                 player?.RefillDash();
-                Audio.Play("event:/game/general/diamond_touch", Position);
+                if (soundOnDashed) {
+                    Audio.Play("event:/game/general/diamond_touch", Position);
+                }
             }
         }
     }

--- a/Loenn/entities/fakeMiniHeart.lua
+++ b/Loenn/entities/fakeMiniHeart.lua
@@ -10,7 +10,8 @@ fakeMiniHeart.placements = {
             requireDashToBreak = true,
             noGhostSprite = false,
             particleColor = "",
-            playPulseSound = true
+            playPulseSound = true,
+			playBreakSound = false
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -20,6 +20,7 @@ entities.CollabUtils2/FakeMiniHeart.attributes.description.requireDashToBreak=Wh
 entities.CollabUtils2/FakeMiniHeart.attributes.description.noGhostSprite=If checked, the heart will never use the "ghost" sprite even when already collected.
 entities.CollabUtils2/FakeMiniHeart.attributes.description.particleColor=The color of the particles emitted by the fake mini heart. Leave empty to use default colors.
 entities.CollabUtils2/FakeMiniHeart.attributes.description.playPulseSound=Whether the heart should play a sound along with its pulse.
+entities.CollabUtils2/FakeMiniHeart.attributes.description.playBreakSound=Whether the heart should play a refill sound when broken.
 
 # Mini Heart Door
 entities.CollabUtils2/MiniHeartDoor.placements.name.door=Mini Heart Door


### PR DESCRIPTION
Previously, dashing through a fake mini heart would restore dashes but didn't have any corresponding sound. Now it'll play the refill gem break sound.