### PR TITLE
Disable retry when using the lobby map UI

### DIFF
--- a/Entities/LobbyMapWarp.cs
+++ b/Entities/LobbyMapWarp.cs
@@ -48,6 +48,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
 
         private void onTalk(Player player) {
             if (player.Scene is Level level) {
+                level.CanRetry = false;
                 if (level.Tracker.GetEntity<LobbyMapController>() is LobbyMapController lmc) {
                     lmc.VisitManager?.ActivateWarp(info.MarkerId);
                 }

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -102,6 +102,8 @@ namespace Celeste.Mod.CollabUtils2.UI {
             openedWithRevealMap = CollabModule.Instance.SaveData.RevealMap;
 
             if (scene is Level level && level.Tracker.GetEntity<Player>() is Player player) {
+                level.CanRetry = false;
+
                 var path = player.Inventory.Backpack ? "marker/runBackpack" : "marker/runNoBackpack";
                 Add(maddyRunSprite = new Sprite(MTN.Mountain, path));
                 maddyRunSprite.Justify = new Vector2(0.5f, 1f);
@@ -128,6 +130,10 @@ namespace Celeste.Mod.CollabUtils2.UI {
             renderTarget = null;
             overlayTexture = null;
             mapTexture = null;
+
+            if (scene is Level level) {
+                level.CanRetry = true;
+            }
         }
 
         public override void Update() {


### PR DESCRIPTION
Disables retry when interacting with a warp, and also when the screen appears.  This covers the case where the player has forced the UI open via console.

Resolves #77 