### PR TITLE
Lobby Map sorting fix and debug commands

### DIFF
--- a/CollabModule.cs
+++ b/CollabModule.cs
@@ -169,11 +169,45 @@ namespace Celeste.Mod.CollabUtils2 {
         }
 
         /// <summary>
-        /// Toggles the fog-of-war effect on the lobby map.
+        /// Enables or disables the exploration mask effect on the lobby map.
         /// </summary>
-        [Command("cu2_lobby_map_reveal", "Toggles the fog-of-war effect on the lobby map")]
-        private static void CmdToggleMapReveal() {
-            Instance.SaveData.RevealMap = !Instance.SaveData.RevealMap;
+        [Command("cu2_lobby_map_reveal", "Temporarily reveals or hides unexplored areas on the lobby map (0 = hidden, 1 = revealed)")]
+        private static void CmdLobbyMapReveal(int revealed = -1) {
+            if (revealed == -1) {
+                Engine.Commands.Log($"Unexplored areas are currently {(Instance.SaveData.RevealMap ? "revealed" : "hidden")}");
+                return;
+            }
+
+            Instance.SaveData.RevealMap = revealed == 1;
+            Engine.Commands.Log($"Unexplored areas are now {(Instance.SaveData.RevealMap ? "revealed" : "hidden")}");
+        }
+
+        /// <summary>
+        /// Pauses or unpauses the active LobbyVisitManager.
+        /// </summary>
+        [Command("cu2_lobby_map_pause", "Pauses updating the lobby map (0 = unpaused, 1 = paused)")]
+        private static void CmdLobbyMapPause(int paused = -1) {
+            if (paused == -1) {
+                Engine.Commands.Log($"Visiting lobby map points is currently {(Instance.SaveData.PauseVisitingPoints ? "paused" : "unpaused")}");
+                return;
+            }
+
+            Instance.SaveData.PauseVisitingPoints = paused == 1;
+            Engine.Commands.Log($"Visiting lobby map points is now {(Instance.SaveData.PauseVisitingPoints ? "paused" : "unpaused")}");
+        }
+
+        /// <summary>
+        /// Shows or hides visited points for the current lobby map.
+        /// </summary>
+        [Command("cu2_lobby_map_debug", "Shows or hides visited points on the map (0 = hidden, 1 = visible)")]
+        private static void CmdLobbyMapDebug(int visible = -1) {
+            if (visible == -1) {
+                Engine.Commands.Log($"Visited points are currently {(Instance.SaveData.ShowVisitedPoints ? "visible" : "hidden")}");
+                return;
+            }
+
+            Instance.SaveData.ShowVisitedPoints = visible == 1;
+            Engine.Commands.Log($"Visited points are now {(Instance.SaveData.ShowVisitedPoints ? "visible" : "hidden")}");
         }
 
         /// <summary>

--- a/CollabSaveData.cs
+++ b/CollabSaveData.cs
@@ -28,5 +28,9 @@ namespace Celeste.Mod.CollabUtils2 {
 
         // whether the map should be forced visible, regardless of exploration
         public bool RevealMap { get; set; }
+        // whether the visit manager should pause visiting points, useful for TAS routing
+        public bool PauseVisitingPoints { get; set; }
+        // whether the lobby map controller should show visited points, useful for TAS routing
+        public bool ShowVisitedPoints { get; set; }
     }
 }

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -569,8 +569,15 @@ namespace Celeste.Mod.CollabUtils2.UI {
         public override void Render() {
             drawBackground();
             drawMap();
+
             base.Render();
+
             maddyRunSprite?.Render();
+
+            if (CollabModule.Instance.SaveData.ShowVisitedPoints) {
+                drawVisitedPoints();
+            }
+
             drawForeground();
         }
 
@@ -677,6 +684,25 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private void drawMap() {
             if (renderTarget?.IsDisposed != false) return;
             Draw.SpriteBatch.Draw(renderTarget, new Vector2(windowBounds.Left, windowBounds.Top), Color.White);
+        }
+
+        /// <summary>
+        /// Draw every visited point.
+        /// </summary>
+        private void drawVisitedPoints() {
+            if (visitManager == null) return;
+
+            var scale = finalScale;
+            var actualWidth = mapTexture.Width * scale;
+            var actualHeight = mapTexture.Height * scale;
+
+            foreach (var visitedPoint in visitManager.VisitedPoints) {
+                var origin = originForPosition(visitedPoint.Point * Vector2.One * 8);
+                var originOffset = origin - actualOrigin;
+                var pointX = mapBounds.Center.X + originOffset.X * actualWidth;
+                var pointY = mapBounds.Center.Y + originOffset.Y * actualHeight;
+                Draw.Rect(pointX - 1, pointY - 1, 3, 3, Color.Red);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
There's currently an issue with `LobbyVisitManager` where:
* Sorting is being done in the opposite direction
* Sorting is only ever done when you first enter the level

The first issue was just the comparison being done in reverse, the second issue is due to checking the sort distance threshold using "last visited point" rather than "nearest sorted point".  Both of these are now fixed, which will prevent problems like this:

<img width="340" alt="image" src="https://user-images.githubusercontent.com/2331297/226578766-7460178d-ca01-4ab5-8b41-6f0fdf6729c7.png">

Additionally, I've added some more console commands that should be useful for testing or TASing.
* `cu2_lobby_map_reveal`: Already existed, but now it accepts `0` or `1` to disable or enable respectively.
* `cu2_lobby_map_pause`: Will temporarily prevent the visit manager from adding points. Accepts `0` or `1`.
* `cu2_lobby_map_debug`: Displays a small rectangle in the world at each visited point, with lines pointing to the nearest 3 in the most recent sort. Also displays a small dot on the lobby map at each visited point. Accepts `0` or `1`.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/2331297/226580542-5008ef15-61cf-45a9-840e-405751223146.png">

<img width="960" alt="image" src="https://user-images.githubusercontent.com/2331297/226580782-33824a25-ef6f-4c6e-a24e-9d9d80de3bf4.png">
