### PR TITLE
Abort displaying the lobby map if the player is not standing in front

### DIFF
--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -139,6 +139,12 @@ namespace Celeste.Mod.CollabUtils2.UI {
         public override void Update() {
             base.Update();
 
+            // if we're somehow not on the ground, bail
+            if (Scene?.Tracker.GetEntity<Player>()?.OnGround() != true) {
+                closeScreen();
+                return;
+            }
+
             // handle input
             if (focused) {
                 if (activeWarps.Count > 0) {


### PR DESCRIPTION
Fixes a menu storage bug that allows arbitrary spawn point warping in lobbies.