### PR TITLE
Lobby Map Enhancements

### DIFF
--- a/CollabSession.cs
+++ b/CollabSession.cs
@@ -1,6 +1,4 @@
 
-using Microsoft.Xna.Framework;
-
 namespace Celeste.Mod.CollabUtils2 {
     public class CollabSession : EverestModuleSession {
         public string LobbySID { get; set; } = null;

--- a/CollabSettings.cs
+++ b/CollabSettings.cs
@@ -1,10 +1,25 @@
 
+using Microsoft.Xna.Framework.Input;
+
 namespace Celeste.Mod.CollabUtils2 {
     public class CollabSettings : EverestModuleSettings {
         public enum SpeedBerryTimerPositions { TopLeft, TopCenter };
         public enum BestTimeInJournal { SpeedBerry, ChapterTimer };
 
+        [DefaultButtonBinding(Buttons.LeftTrigger, Keys.Tab)]
         public ButtonBinding DisplayLobbyMap { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickUp, Keys.None)]
+        public ButtonBinding PanLobbyMapUp { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickDown, Keys.None)]
+        public ButtonBinding PanLobbyMapDown { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickLeft, Keys.None)]
+        public ButtonBinding PanLobbyMapLeft { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickRight, Keys.None)]
+        public ButtonBinding PanLobbyMapRight { get; set; }
 
         public SpeedBerryTimerPositions SpeedBerryTimerPosition { get; set; } = SpeedBerryTimerPositions.TopLeft;
 

--- a/CollabSettings.cs
+++ b/CollabSettings.cs
@@ -1,24 +1,14 @@
 
-using Microsoft.Xna.Framework.Input;
-
 namespace Celeste.Mod.CollabUtils2 {
     public class CollabSettings : EverestModuleSettings {
         public enum SpeedBerryTimerPositions { TopLeft, TopCenter };
         public enum BestTimeInJournal { SpeedBerry, ChapterTimer };
 
-        [DefaultButtonBinding(Buttons.LeftTrigger, Keys.Tab)]
         public ButtonBinding DisplayLobbyMap { get; set; }
-
-        [DefaultButtonBinding(Buttons.RightThumbstickUp, Keys.None)]
+        public ButtonBinding HoldToPan { get; set; }
         public ButtonBinding PanLobbyMapUp { get; set; }
-
-        [DefaultButtonBinding(Buttons.RightThumbstickDown, Keys.None)]
         public ButtonBinding PanLobbyMapDown { get; set; }
-
-        [DefaultButtonBinding(Buttons.RightThumbstickLeft, Keys.None)]
         public ButtonBinding PanLobbyMapLeft { get; set; }
-
-        [DefaultButtonBinding(Buttons.RightThumbstickRight, Keys.None)]
         public ButtonBinding PanLobbyMapRight { get; set; }
 
         public SpeedBerryTimerPositions SpeedBerryTimerPosition { get; set; } = SpeedBerryTimerPositions.TopLeft;
@@ -31,5 +21,9 @@ namespace Celeste.Mod.CollabUtils2 {
         public BestTimeInJournal BestTimeToDisplayInJournal { get; set; } = BestTimeInJournal.SpeedBerry;
 
         public bool SaveByDefaultWhenReturningToLobby { get; set; } = true;
+
+        // whether we've notified the user about new lobby map keybinds
+        [SettingIgnore]
+        public bool NewLobbyMapKeybindsNotified { get; set; }
     }
 }

--- a/CollabSettings.cs
+++ b/CollabSettings.cs
@@ -4,6 +4,8 @@ namespace Celeste.Mod.CollabUtils2 {
         public enum SpeedBerryTimerPositions { TopLeft, TopCenter };
         public enum BestTimeInJournal { SpeedBerry, ChapterTimer };
 
+        public ButtonBinding DisplayLobbyMap { get; set; }
+
         public SpeedBerryTimerPositions SpeedBerryTimerPosition { get; set; } = SpeedBerryTimerPositions.TopLeft;
 
         public bool HideSpeedBerryTimerDuringGameplay { get; set; } = false;

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -54,4 +54,6 @@ collabutils2_lobbymap_change_destination= Change Destination
 collabutils2_lobbymap_change_lobby= Change Lobby
 collabutils2_lobbymap_close= Close
 collabutils2_lobbymap_confirm= Confirm
+collabutils2_lobbymap_hold_to_pan= Hold to Pan
+collabutils2_lobbymap_pan= Pan
 collabutils2_lobbymap_zoom= Zoom

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -45,6 +45,13 @@ modoptions_collab_besttimetodisplayinjournal_chaptertimer= Chapter Time
 
 modoptions_collab_savebydefaultwhenreturningtolobby= Save and Return to Lobby By Default
 
+modoptions_collab_displaylobbymap= Display Lobby Map
+modoptions_collab_holdtopan= Hold to Pan
+modoptions_collab_panlobbymapup= Pan Lobby Map Up
+modoptions_collab_panlobbymapdown= Pan Lobby Map Down
+modoptions_collab_panlobbymapleft= Pan Lobby Map Left
+modoptions_collab_panlobbymapright= Pan Lobby Map Right
+
 collabutils2_assist_skip= Open Heart Gate
 collabutils2_assist_skip_confirm= This will open the Heart Gate permanently.{n}Are you sure?
 collabutils2_assist_skip_confirm_yes= Yes
@@ -57,3 +64,4 @@ collabutils2_lobbymap_confirm= Confirm
 collabutils2_lobbymap_hold_to_pan= Hold to Pan
 collabutils2_lobbymap_pan= Pan
 collabutils2_lobbymap_zoom= Zoom
+collabutils2_lobbymap_notify_keybinds= New keybinds are available in Mod Options!

--- a/Entities/LobbyMapController.cs
+++ b/Entities/LobbyMapController.cs
@@ -32,6 +32,21 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 level.Tracker.GetEntity<LobbyMapUI>() == null &&
                 level.Tracker.GetEntity<Player>() is Player player) {
 
+                // check if the player pressed the lobby map button and we're on the ground
+                if (CollabModule.Instance.Settings.DisplayLobbyMap.Pressed && level.CanRetry &&
+                    player.StateMachine.State == Player.StNormal && player.OnGround() &&
+                    level.Tracker.GetEntity<LobbyMapUI>() == null) {
+
+                    // stop us from retrying
+                    level.CanRetry = false;
+                    // set dummy state
+                    player.StateMachine.State = Player.StDummy;
+                    // display the lobby map view only
+                    level.Add(new LobbyMapUI(true));
+                    // don't do any more
+                    return;
+                }
+
                 if (!level.OnInterval(0.2f) || player.StateMachine.State == Player.StDummy || CollabModule.Instance.SaveData.PauseVisitingPoints) {
                     return;
                 }

--- a/Entities/LobbyMapController.cs
+++ b/Entities/LobbyMapController.cs
@@ -32,9 +32,9 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 level.Tracker.GetEntity<LobbyMapUI>() == null &&
                 level.Tracker.GetEntity<Player>() is Player player) {
 
-                // check if the player pressed the lobby map button and we're on the ground
+                // check if the player pressed the lobby map button and we're on the ground or swimming
                 if (CollabModule.Instance.Settings.DisplayLobbyMap.Pressed && level.CanRetry &&
-                    player.StateMachine.State == Player.StNormal && player.OnGround() &&
+                    (player.StateMachine.State == Player.StNormal && player.OnGround() || player.StateMachine.State == Player.StSwim) &&
                     level.Tracker.GetEntity<LobbyMapUI>() == null) {
 
                     // if we're standing in front of a bench, trigger it instead
@@ -43,12 +43,12 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                         return;
                     }
 
-                    // stop us from retrying
-                    level.CanRetry = false;
-                    // set dummy state
-                    player.StateMachine.State = Player.StDummy;
+                    // lock the player from doing anything
+                    LobbyMapUI.SetLocked(true, level, player);
+
                     // display the lobby map view only
                     level.Add(new LobbyMapUI(true));
+
                     // don't do any more
                     return;
                 }

--- a/Entities/LobbyMapController.cs
+++ b/Entities/LobbyMapController.cs
@@ -37,6 +37,12 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                     player.StateMachine.State == Player.StNormal && player.OnGround() &&
                     level.Tracker.GetEntity<LobbyMapUI>() == null) {
 
+                    // if we're standing in front of a bench, trigger it instead
+                    if (player.CollideFirst<LobbyMapWarp>() is LobbyMapWarp warp) {
+                        warp.OnTalk(player);
+                        return;
+                    }
+
                     // stop us from retrying
                     level.CanRetry = false;
                     // set dummy state

--- a/Entities/LobbyMapWarp.cs
+++ b/Entities/LobbyMapWarp.cs
@@ -6,6 +6,7 @@ using Monocle;
 using System.Collections;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
+    [Tracked]
     [CustomEntity("CollabUtils2/LobbyMapWarp")]
     public class LobbyMapWarp : Entity {
         private readonly string warpSpritePath;
@@ -34,7 +35,11 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 image.JustifyOrigin(0.5f, 1f);
             }
 
-            Add(new TalkComponent(new Rectangle(-16, -32, 32, 32), new Vector2(0, data.Float("interactOffsetY", -16f)), onTalk) {
+            var talkRect = new Rectangle(-16, -32, 32, 32);
+            Collidable = true;
+            Collider = new Hitbox(talkRect.Width, talkRect.Height, talkRect.X, talkRect.Y);
+
+            Add(new TalkComponent(talkRect, new Vector2(0, data.Float("interactOffsetY", -16f)), OnTalk) {
                 PlayerMustBeFacing = false,
             });
         }
@@ -46,7 +51,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             info.Room = level.Session.Level;
         }
 
-        private void onTalk(Player player) {
+        public void OnTalk(Player player) {
             // don't allow this to somehow trigger twice from the same action
             if (player.Scene is Level level && level.CanRetry) {
                 level.CanRetry = false;

--- a/Entities/LobbyMapWarp.cs
+++ b/Entities/LobbyMapWarp.cs
@@ -54,7 +54,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         public void OnTalk(Player player) {
             // don't allow this to somehow trigger twice from the same action
             if (player.Scene is Level level && level.CanRetry) {
-                level.CanRetry = false;
+                LobbyMapUI.SetLocked(true);
                 if (level.Tracker.GetEntity<LobbyMapController>() is LobbyMapController lmc) {
                     lmc.VisitManager?.ActivateWarp(info.MarkerId);
                 }
@@ -69,13 +69,13 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         private IEnumerator activateRoutine(Player player) {
             if (player == null) yield break;
 
-            player.StateMachine.State = Player.StDummy;
+            LobbyMapUI.SetLocked(true, Scene, player);
             yield return player.DummyWalkToExact((int)X, false, 1f, true);
 
             // handle the case where we're dead or not on the ground in front of it
             if (!validPlayer(player)) {
                 if (!player.Dead) {
-                    player.StateMachine.State = Player.StNormal;
+                    LobbyMapUI.SetLocked(false, Scene, player);
                 }
                 yield break;
             }
@@ -99,8 +99,8 @@ namespace Celeste.Mod.CollabUtils2.Entities {
 
             // loop until animation is finished or the player can no longer use the bench
             while (playerSprite.Animating && validPlayer(player)) {
-                // force dummy state while animating
-                player.StateMachine.State = Player.StDummy;
+                // force locked while animating to prevent jank
+                LobbyMapUI.SetLocked(true, Scene, player);
                 yield return null;
             }
 
@@ -108,7 +108,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             if (validPlayer(player)) {
                 player.Scene.Add(new LobbyMapUI());
             } else {
-                player.StateMachine.State = Player.StNormal;
+                LobbyMapUI.SetLocked(false, Scene, player);
             }
 
             yield return 0.5f;

--- a/Entities/MiniHeartDoorUnlockCutscene.cs
+++ b/Entities/MiniHeartDoorUnlockCutscene.cs
@@ -2,8 +2,6 @@ using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     class MiniHeartDoorUnlockCutscene : CutsceneEntity {

--- a/Entities/SceneRenderer.cs
+++ b/Entities/SceneRenderer.cs
@@ -1,16 +1,4 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Monocle;
-using MonoMod.RuntimeDetour;
-using MonoMod.Utils;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.CollabUtils2.Entities {
     public class SceneRenderer : Renderer {

--- a/Entities/StrawberryHooks.cs
+++ b/Entities/StrawberryHooks.cs
@@ -1,4 +1,3 @@
-using Celeste.Mod.CollabUtils2.UI;
 using Microsoft.Xna.Framework;
 using Mono.Cecil;
 using Mono.Cecil.Cil;

--- a/LobbyHelper.cs
+++ b/LobbyHelper.cs
@@ -1,6 +1,5 @@
 using Celeste.Mod.CelesteNet.Client.Components;
 using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CollabUtils2.Entities;
 using Celeste.Mod.CollabUtils2.UI;
 using Celeste.Mod.UI;
 using Mono.Cecil;

--- a/Triggers/JournalTrigger.cs
+++ b/Triggers/JournalTrigger.cs
@@ -1,12 +1,7 @@
-using Celeste.Mod.CollabUtils2.Entities;
 using Celeste.Mod.CollabUtils2.UI;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
-using Monocle;
 using MonoMod.Utils;
-using System;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace Celeste.Mod.CollabUtils2.Triggers {
     [CustomEntity("CollabUtils2/JournalTrigger")]

--- a/UI/AreaCompleteInfoInLevel.cs
+++ b/UI/AreaCompleteInfoInLevel.cs
@@ -1,5 +1,4 @@
 using Microsoft.Xna.Framework;
-using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;

--- a/UI/ButtonHelper.cs
+++ b/UI/ButtonHelper.cs
@@ -1,0 +1,115 @@
+using Microsoft.Xna.Framework;
+using Monocle;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.CollabUtils2.UI {
+    public static class ButtonHelper {
+        // cached for performance
+        private static readonly List<MTexture> multiButtonTextures = new List<MTexture>();
+
+        public static void RenderMultiButton(ref Vector2 position, float xAdvance, ButtonRenderInfo renderInfo, float scale = 1f, float alpha = 1f, float justifyX = 0.5f, float wiggle = 1f, Wiggler wiggler = null) {
+            var width = RenderMultiButton(position, renderInfo, scale, alpha, justifyX, wiggle, wiggler);
+            if (justifyX < 0.5f)
+                position.X += width + xAdvance;
+            else
+                position.X -= width + xAdvance;
+        }
+
+        /// <summary>
+        /// Draws a multi button.
+        /// </summary>
+        public static float RenderMultiButton(Vector2 position, ButtonRenderInfo renderInfo, float scale = 1f, float alpha = 1f, float justifyX = 0.5f, float wiggle = 1f, Wiggler wiggler = null) {
+            var textures = getTextures(renderInfo);
+
+            float buttonWidths = 0;
+            foreach (var texture in textures) {
+                buttonWidths += texture?.Width ?? 0;
+            }
+
+            float labelWidth = ActiveFont.Measure(renderInfo.Label).X;
+            float fullWidth = labelWidth + 8f + buttonWidths;
+            float labelJustifyX = fullWidth / 2f / labelWidth;
+
+            position.X += scale * fullWidth * (0.5f - justifyX);
+            wiggle *= (wiggler ?? renderInfo.Wiggler)?.Value ?? 1f;
+
+            drawText(renderInfo.Label, position, labelJustifyX, scale + wiggle, alpha);
+
+            float buttonX = labelWidth + 8f - fullWidth / 2f;
+            for (int i = 0; i < textures.Count; i++) {
+                if (multiButtonTextures[i] is MTexture texture) {
+                    var origin = new Vector2(-buttonX, texture.Height / 2f);
+                    buttonX += texture.Width;
+                    float ba = renderInfo.AlphaForButtonIndex(i);
+                    if (ba > 0) {
+                        texture.Draw(position, origin, Color.White * alpha * ba, scale + wiggle);
+                    }
+                }
+            }
+
+            return fullWidth * scale;
+        }
+
+        /// <summary>
+        /// Draws text for a double button in the specified position.
+        /// </summary>
+        private static void drawText(string text, Vector2 position, float justifyX, float scale, float alpha) {
+            ActiveFont.DrawOutline(text, position, new Vector2(justifyX, 0.5f), Vector2.One * scale, Color.White * alpha, 2f, Color.Black * alpha);
+        }
+
+        private static List<MTexture> getTextures(ButtonRenderInfo renderInfo) {
+            multiButtonTextures.Clear();
+            var fallback = renderInfo.ShowFallback ? "controls/keyboard/oemquestion" : null;
+            if (renderInfo.Button1 != null) multiButtonTextures.Add(Input.GuiButton(renderInfo.Button1, fallback));
+            if (renderInfo.Button2 != null) multiButtonTextures.Add(Input.GuiButton(renderInfo.Button2, fallback));
+            if (renderInfo.Button3 != null) multiButtonTextures.Add(Input.GuiButton(renderInfo.Button3, fallback));
+            if (renderInfo.Button4 != null) multiButtonTextures.Add(Input.GuiButton(renderInfo.Button4, fallback));
+            return multiButtonTextures;
+        }
+
+        public struct ButtonRenderInfo {
+            public readonly string Label;
+            public readonly VirtualButton Button1;
+            public readonly VirtualButton Button2;
+            public readonly VirtualButton Button3;
+            public readonly VirtualButton Button4;
+            public readonly int ButtonCount;
+            public readonly bool ShowFallback;
+            public readonly Wiggler Wiggler;
+
+            public float Button1Alpha;
+            public float Button2Alpha;
+            public float Button3Alpha;
+            public float Button4Alpha;
+
+            public ButtonRenderInfo(
+                string label,
+                VirtualButton button1 = null,
+                VirtualButton button2 = null,
+                VirtualButton button3 = null,
+                VirtualButton button4 = null,
+                Wiggler wiggler = null,
+                bool showFallback = true) {
+                Label = label;
+                Button1 = button1;
+                Button2 = button2;
+                Button3 = button3;
+                Button4 = button4;
+                Wiggler = wiggler;
+                ButtonCount = button1 == null ? 0 : button2 == null ? 1 : button3 == null ? 2 : button4 == null ? 3 : 4;
+                ShowFallback = showFallback;
+                Button1Alpha = Button2Alpha = Button3Alpha = Button4Alpha = 1f;
+            }
+
+            public float AlphaForButtonIndex(int index) {
+                switch (index) {
+                    case 0: return Button1Alpha;
+                    case 1: return Button2Alpha;
+                    case 2: return Button3Alpha;
+                    case 3: return Button4Alpha;
+                    default: return 0f;
+                }
+            }
+        }
+    }
+}

--- a/UI/ButtonHelper.cs
+++ b/UI/ButtonHelper.cs
@@ -7,12 +7,16 @@ namespace Celeste.Mod.CollabUtils2.UI {
         // cached for performance
         private static readonly List<MTexture> multiButtonTextures = new List<MTexture>();
 
+        /// <summary>
+        /// Draws a multi button, and automatically advances the rendering position based on the width.
+        /// </summary>
         public static void RenderMultiButton(ref Vector2 position, float xAdvance, ButtonRenderInfo renderInfo, float scale = 1f, float alpha = 1f, float justifyX = 0.5f, float wiggle = 1f, Wiggler wiggler = null) {
             var width = RenderMultiButton(position, renderInfo, scale, alpha, justifyX, wiggle, wiggler);
-            if (justifyX < 0.5f)
+            if (justifyX < 0.5f) {
                 position.X += width + xAdvance;
-            else
+            } else {
                 position.X -= width + xAdvance;
+            }
         }
 
         /// <summary>
@@ -57,6 +61,10 @@ namespace Celeste.Mod.CollabUtils2.UI {
             ActiveFont.DrawOutline(text, position, new Vector2(justifyX, 0.5f), Vector2.One * scale, Color.White * alpha, 2f, Color.Black * alpha);
         }
 
+        /// <summary>
+        /// Gets the textures for each of the buttons in the render info.
+        /// We use a statically cached list for performance.
+        /// </summary>
         private static List<MTexture> getTextures(ButtonRenderInfo renderInfo) {
             multiButtonTextures.Clear();
             var fallback = renderInfo.ShowFallback ? "controls/keyboard/oemquestion" : null;
@@ -67,6 +75,10 @@ namespace Celeste.Mod.CollabUtils2.UI {
             return multiButtonTextures;
         }
 
+        /// <summary>
+        /// Stores the information required for rendering a multi-button.
+        /// <see cref="Button1Alpha"/> and so on should be updated as required before calling RenderMultiButton.
+        /// </summary>
         public struct ButtonRenderInfo {
             public readonly string Label;
             public readonly VirtualButton Button1;

--- a/UI/LevelExitToLobby.cs
+++ b/UI/LevelExitToLobby.cs
@@ -1,4 +1,3 @@
-using FMOD.Studio;
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -17,11 +17,11 @@ namespace Celeste.Mod.CollabUtils2.UI {
         #region Fields
 
         // input handling
-        private static VirtualJoystick lobbyMapJoystick;
-        private static VirtualButton lobbyMapUpButton;
-        private static VirtualButton lobbyMapDownButton;
-        private static VirtualButton lobbyMapLeftButton;
-        private static VirtualButton lobbyMapRightButton;
+        private readonly VirtualJoystick lobbyMapJoystick;
+        private readonly VirtualButton lobbyMapUpButton;
+        private readonly VirtualButton lobbyMapDownButton;
+        private readonly VirtualButton lobbyMapLeftButton;
+        private readonly VirtualButton lobbyMapRightButton;
 
         // cached button render info
         private ButtonHelper.ButtonRenderInfo changeDestinationButtonRenderInfo;
@@ -101,17 +101,15 @@ namespace Celeste.Mod.CollabUtils2.UI {
             Depth = Depths.FGTerrain - 2;
             Visible = false;
 
-            if (lobbyMapJoystick == null) {
-                lobbyMapJoystick = new VirtualJoystick(
-                    CollabModule.Instance.Settings.PanLobbyMapUp.Binding,
-                    CollabModule.Instance.Settings.PanLobbyMapDown.Binding,
-                    CollabModule.Instance.Settings.PanLobbyMapLeft.Binding,
-                    CollabModule.Instance.Settings.PanLobbyMapRight.Binding, Input.Gamepad, 0.1f);
-                lobbyMapUpButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapUp.Binding, Input.Gamepad, 0f, 0.4f);
-                lobbyMapDownButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapDown.Binding, Input.Gamepad, 0f, 0.4f);
-                lobbyMapLeftButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapLeft.Binding, Input.Gamepad, 0f, 0.4f);
-                lobbyMapRightButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapRight.Binding, Input.Gamepad, 0f, 0.4f);
-            }
+            lobbyMapJoystick = new VirtualJoystick(
+                CollabModule.Instance.Settings.PanLobbyMapUp.Binding,
+                CollabModule.Instance.Settings.PanLobbyMapDown.Binding,
+                CollabModule.Instance.Settings.PanLobbyMapLeft.Binding,
+                CollabModule.Instance.Settings.PanLobbyMapRight.Binding, Input.Gamepad, 0.1f);
+            lobbyMapUpButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapUp.Binding, Input.Gamepad, 0f, 0.4f);
+            lobbyMapDownButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapDown.Binding, Input.Gamepad, 0f, 0.4f);
+            lobbyMapLeftButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapLeft.Binding, Input.Gamepad, 0f, 0.4f);
+            lobbyMapRightButton = new VirtualButton(CollabModule.Instance.Settings.PanLobbyMapRight.Binding, Input.Gamepad, 0f, 0.4f);
 
             this.viewOnly = viewOnly;
 

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -267,9 +267,14 @@ namespace Celeste.Mod.CollabUtils2.UI {
                         targetOrigin = shouldCentreOrigin ? new Vector2(0.5f) : selectedOrigin;
                         translateTimeRemaining = translate_time_seconds;
                     }
-                } else if (!shouldCentreOrigin && translateTimeRemaining <= 0 && scaleTimeRemaining <= 0 && aiming) {
-                    var aspectRatio = (float)mapBounds.Width / mapBounds.Height;
-                    var offset = aim * 2f / actualScale / new Vector2(aspectRatio, 1f);
+                } else if (!shouldCentreOrigin && translateTimeRemaining <= 0 && scaleTimeRemaining <= 0 && aiming && mapTexture != null) {
+                    var aspectRatio = (float)mapTexture.Width / mapTexture.Height;
+                    var offset = aim.SafeNormalize() * 2f / actualScale;
+                    if (aspectRatio > 0) {
+                        offset.X /= aspectRatio;
+                    } else {
+                        offset.Y *= aspectRatio;
+                    }
                     var newOrigin = actualOrigin + offset * Engine.DeltaTime;
                     actualOrigin = newOrigin.Clamp(0, 0, 1, 1);
                     updateMarkers();

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -277,6 +277,18 @@ namespace Celeste.Mod.CollabUtils2.UI {
                     }
                     var newOrigin = actualOrigin + offset * Engine.DeltaTime;
                     actualOrigin = newOrigin.Clamp(0, 0, 1, 1);
+
+                    // update the selected warp if we should
+                    if (!viewOnly && !shouldCentreOrigin) {
+                        var nearestWarpIndex = nearestWarpIndexToActualOrigin();
+                        if (nearestWarpIndex != selectedWarpIndexes[selectedLobbyIndex]) {
+                            Audio.Play(nearestWarpIndex < selectedWarpIndexes[selectedLobbyIndex] ? "event:/ui/main/rollover_up" : "event:/ui/main/rollover_down");
+                            selectedWarpIndexes[selectedLobbyIndex] = lastSelectedWarpIndex = nearestWarpIndex;
+                            selectedOrigin = originForPosition(activeWarps[nearestWarpIndex].Position);
+                        }
+                    }
+
+                    // make sure the markers are in the right place
                     updateMarkers();
                 }
 
@@ -322,6 +334,23 @@ namespace Celeste.Mod.CollabUtils2.UI {
 
                 lastSelectedWarpIndex = selectedWarpIndexes[selectedLobbyIndex];
             }
+        }
+
+        /// <summary>
+        /// Finds the index into <see cref="activeWarps"/> that has the nearest warp to <see cref="actualOrigin"/>.
+        /// </summary>
+        private int nearestWarpIndexToActualOrigin() {
+            int nearestIndex = -1;
+            var nearestLengthSquared = float.MaxValue;
+            for (int i = 0; i < activeWarps.Count; i++) {
+                var warpOrigin = originForPosition(activeWarps[i].Position);
+                var warpLengthSquared = (actualOrigin - warpOrigin).LengthSquared();
+                if (warpLengthSquared < nearestLengthSquared) {
+                    nearestLengthSquared = warpLengthSquared;
+                    nearestIndex = i;
+                }
+            }
+            return nearestIndex;
         }
 
         #endregion

--- a/UI/OuiHelper_EnterChapterPanel.cs
+++ b/UI/OuiHelper_EnterChapterPanel.cs
@@ -1,12 +1,5 @@
-using FMOD.Studio;
-using Microsoft.Xna.Framework;
 using Monocle;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.CollabUtils2.UI {
     public class OuiHelper_EnterChapterPanel : Oui {

--- a/UI/OuiHelper_EnterJournal.cs
+++ b/UI/OuiHelper_EnterJournal.cs
@@ -1,12 +1,5 @@
-using FMOD.Studio;
-using Microsoft.Xna.Framework;
 using Monocle;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.CollabUtils2.UI {
     public class OuiHelper_EnterJournal : Oui {


### PR DESCRIPTION
Adds a bunch of enhancements to the lobby map, and makes the interaction storage prevention slightly better.

* New "view-only" map when pressing a configurable keybind (defaults to left trigger and the tab key).  Can only be used in lobbies while on the ground or in water.  You cannot warp to benches from this map, however pressing the view map hotkey while in front of a bench is the same as interacting with the bench.
* Add the ability to pan around the map using configurable keybinds (defaults to right stick, but no keys).  If no panning keybinds are configured for the latest input method, players can hold grab to use their aim binds for panning.  Panning will automatically select the nearest bench to the centre of the screen.
* Moved the button rendering to a separate helper class that supports up to four `VirtualButton`s for a single label, with customisable alpha per button glyph.  Storing the button render configuration in a struct makes the call to `RenderMultiButton` cleaner and allows us to set it up in the constructor.
* Cleaned up some redundant using directives.

~~I'm *slightly* concerned about the defaults for opening the view-only map given that it could easily conflict with players' current setups.  Without defaults no-one is going to know it exists so I'm not sure what to do here.  If there's a conflict it's trivial to change but again they need to know it's there.  I'm considering making the "hold to pan" configurable too since the grab button can conflict with the journal button for some controller players.~~

These are now all configurable, and a "New keybinds are available in Mod Options!" message displays the first time the player opens the map after installing/updating CU2.