### PR TITLE
Lobby map multi-room fixes

### DIFF
--- a/Ahorn/entities/lobbyMapController.jl
+++ b/Ahorn/entities/lobbyMapController.jl
@@ -4,7 +4,7 @@ using ..Ahorn, Maple
 
 @mapdef Entity "CollabUtils2/LobbyMapController" LobbyMapController(
     x::Integer, y::Integer,
-    mapTexture::String="", totalMaps::Integer=10, customMarkers::String="",
+    mapTexture::String="", totalMaps::Integer=10, roomIndex::Integer=0, customMarkers::String="",
     warpIcon::String="CollabUtils2/lobbies/warp", rainbowBerryIcon::String="CollabUtils2/lobbies/rainbowBerry",
     heartGateIcon::String="CollabUtils2/lobbies/heartgate", gymIcon::String="CollabUtils2/lobbies/gym",
     mapIcon::String="CollabUtils2/lobbies/map", journalIcon::String="CollabUtils2/lobbies/journal",

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -64,4 +64,4 @@ collabutils2_lobbymap_confirm= Confirm
 collabutils2_lobbymap_hold_to_pan= Hold to Pan
 collabutils2_lobbymap_pan= Pan
 collabutils2_lobbymap_zoom= Zoom
-collabutils2_lobbymap_notify_keybinds= New keybinds are available in Mod Options!
+collabutils2_lobbymap_notify_keybinds= Map keybinds are available under Mod Options > Collab Utils 2

--- a/Entities/LobbyMapController.cs
+++ b/Entities/LobbyMapController.cs
@@ -122,6 +122,12 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             public int TotalMaps;
 
             /// <summary>
+            /// The index to use when sorting rooms within a single map.  Defaults to 0.
+            /// If there is more than one room in a map with the same index, they will be sorted by room name.
+            /// </summary>
+            public int RoomIndex;
+
+            /// <summary>
             /// An array of custom entity names that should be considered <see cref="MarkerType.Map"/> markers.
             /// These entities must have a "map" attribute containing the SID of the target map.
             /// </summary>
@@ -155,6 +161,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
             public ControllerInfo(EntityData data, MapData mapData = null) {
                 MapTexture = data.Attr("mapTexture");
                 TotalMaps = data.Int("totalMaps");
+                RoomIndex = data.Int("roomIndex", 0);
 
                 WarpIcon = data.Attr("warpIcon", "CollabUtils2/lobbies/warp");
                 RainbowBerryIcon = data.Attr("rainbowBerryIcon", "CollabUtils2/lobbies/rainbowBerry");

--- a/Loenn/entities/lobbyMapController.lua
+++ b/Loenn/entities/lobbyMapController.lua
@@ -4,7 +4,10 @@ lobbyMapController.depth = -100
 lobbyMapController.fieldInformation = {
     totalMaps = {
         fieldType = "integer",
-    }
+    },
+    roomIndex = {
+        fieldType = "integer",
+    },
 }
 lobbyMapController.placements = {
     {
@@ -12,6 +15,7 @@ lobbyMapController.placements = {
         data = {
             mapTexture = "",
             totalMaps = 10,
+            roomIndex = 0,
             customMarkers = "",
             warpIcon = "CollabUtils2/lobbies/warp",
             rainbowBerryIcon = "CollabUtils2/lobbies/rainbowBerry",

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -433,8 +433,19 @@ namespace Celeste.Mod.CollabUtils2.UI {
             }
 
             // sort lobbies by SID and room
-            lobbySelections.Sort((lhs, rhs) =>
-                string.Compare($"{lhs.SID}/{lhs.Room}", $"{rhs.SID}/{rhs.Room}", StringComparison.Ordinal));
+            lobbySelections.Sort((lhs, rhs) => {
+                // sort first by sid
+                var compareSid = string.CompareOrdinal(lhs.SID, rhs.SID);
+                if (compareSid != 0) return compareSid;
+
+                // then by room index
+                var compareRoomIndex = Math.Sign(lhs.RoomIndex - rhs.RoomIndex);
+                if (compareRoomIndex != 0) return compareRoomIndex;
+
+                // then by room name
+                return string.CompareOrdinal(lhs.Room, rhs.Room);
+            });
+
             selectedWarpIndexes = new int[lobbySelections.Count];
 
             // select the current lobby
@@ -1194,6 +1205,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             public readonly EntityData Data;
             public readonly string SID;
             public readonly string Room;
+            public readonly int RoomIndex;
             public LobbyMapController.MarkerInfo[] Markers;
 
             public LobbySelection(EntityData data, MapData map) {
@@ -1201,6 +1213,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 Data = data;
                 SID = map.Area.SID;
                 Room = data.Level.Name;
+                RoomIndex = Info.RoomIndex;
             }
         }
 

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -432,16 +432,17 @@ namespace Celeste.Mod.CollabUtils2.UI {
                 }
             }
 
-            // sort lobbies by SID
-            lobbySelections.Sort((lhs, rhs) => string.Compare(lhs.SID, rhs.SID, StringComparison.Ordinal));
+            // sort lobbies by SID and room
+            lobbySelections.Sort((lhs, rhs) =>
+                string.Compare($"{lhs.SID}/{lhs.Room}", $"{rhs.SID}/{rhs.Room}", StringComparison.Ordinal));
             selectedWarpIndexes = new int[lobbySelections.Count];
 
             // select the current lobby
-            selectedLobbyIndex = lobbySelections.FindIndex(s => s.SID == level.Session.Area.SID);
+            selectedLobbyIndex = lobbySelections.FindIndex(s => s.SID == level.Session.Area.SID && s.Room == level.Session.Level);
 
             // verify selection
             if (selectedLobbyIndex < 0) {
-                Logger.Log(LogLevel.Warn, "CollabUtils2/LobbyMapUI", $"getLobbyControllers: Couldn't find map for {level.Session.Area.SID}, defaulting to first");
+                Logger.Log(LogLevel.Warn, "CollabUtils2/LobbyMapUI", $"getLobbyControllers: Couldn't find map for {level.Session.Area.SID}/{level.Session.Level}, defaulting to first");
                 selectedLobbyIndex = 0;
             }
         }
@@ -555,7 +556,7 @@ namespace Celeste.Mod.CollabUtils2.UI {
             actualScale = zoomLevels[zoomLevel];
             shouldCentreOrigin = zoomLevel == 0;
 
-            var isCurrentLobby = selection.SID == level.Session.Area.SID;
+            var isCurrentLobby = selection.SID == level.Session.Area.SID && selection.Room == level.Session.Level;
             shouldShowMaddy = !viewOnly || isCurrentLobby;
 
             if (!viewOnly) {


### PR DESCRIPTION
Fixes a couple of issues when using multiple lobby maps within the same chapter, namely teleporting to the wrong room.
Also clarifies the map keybind location in the hope people stop looking under "Strawberry Jam" for it.