### PR TITLE
Remove Lobby Map keybind notification

### DIFF
--- a/CollabSettings.cs
+++ b/CollabSettings.cs
@@ -1,14 +1,27 @@
 
+using Microsoft.Xna.Framework.Input;
+
 namespace Celeste.Mod.CollabUtils2 {
     public class CollabSettings : EverestModuleSettings {
         public enum SpeedBerryTimerPositions { TopLeft, TopCenter };
         public enum BestTimeInJournal { SpeedBerry, ChapterTimer };
 
+        [DefaultButtonBinding(Buttons.RightStick, Keys.Tab)]
         public ButtonBinding DisplayLobbyMap { get; set; }
+
+        [DefaultButtonBinding(0, Keys.LeftShift)]
         public ButtonBinding HoldToPan { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickUp, 0)]
         public ButtonBinding PanLobbyMapUp { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickDown, 0)]
         public ButtonBinding PanLobbyMapDown { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickLeft, 0)]
         public ButtonBinding PanLobbyMapLeft { get; set; }
+
+        [DefaultButtonBinding(Buttons.RightThumbstickRight, 0)]
         public ButtonBinding PanLobbyMapRight { get; set; }
 
         public SpeedBerryTimerPositions SpeedBerryTimerPosition { get; set; } = SpeedBerryTimerPositions.TopLeft;

--- a/CollabSettings.cs
+++ b/CollabSettings.cs
@@ -21,9 +21,5 @@ namespace Celeste.Mod.CollabUtils2 {
         public BestTimeInJournal BestTimeToDisplayInJournal { get; set; } = BestTimeInJournal.SpeedBerry;
 
         public bool SaveByDefaultWhenReturningToLobby { get; set; } = true;
-
-        // whether we've notified the user about new lobby map keybinds
-        [SettingIgnore]
-        public bool NewLobbyMapKeybindsNotified { get; set; }
     }
 }

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -64,4 +64,3 @@ collabutils2_lobbymap_confirm= Confirm
 collabutils2_lobbymap_hold_to_pan= Hold to Pan
 collabutils2_lobbymap_pan= Pan
 collabutils2_lobbymap_zoom= Zoom
-collabutils2_lobbymap_notify_keybinds= Map keybinds are available under Mod Options > Collab Utils 2

--- a/Dialog/French.txt
+++ b/Dialog/French.txt
@@ -64,4 +64,3 @@ collabutils2_lobbymap_confirm= Confirmer
 collabutils2_lobbymap_hold_to_pan= Maintenir pour Déplacer
 collabutils2_lobbymap_pan= Déplacer
 collabutils2_lobbymap_zoom= Zoom
-collabutils2_lobbymap_notify_keybinds= De nouveaux boutons peuvent être assignés dans les Options des Mods !

--- a/Dialog/Japanese.txt
+++ b/Dialog/Japanese.txt
@@ -64,4 +64,3 @@ collabutils2_lobbymap_confirm= OK
 collabutils2_lobbymap_hold_to_pan= 長押しでロビーマップの画面移動
 collabutils2_lobbymap_pan= 画面移動
 collabutils2_lobbymap_zoom= 倍率を変える
-collabutils2_lobbymap_notify_keybinds= MOD設定 > Collab Utils 2からマップのキー設定をしましょう！

--- a/Dialog/Russian.txt
+++ b/Dialog/Russian.txt
@@ -64,4 +64,3 @@ collabutils2_lobbymap_confirm=              Принять
 collabutils2_lobbymap_hold_to_pan=          Удерживать Для Прокрутки
 collabutils2_lobbymap_pan=                  Прокрутка
 collabutils2_lobbymap_zoom=                 Отдаление
-collabutils2_lobbymap_notify_keybinds=      Новые Кнопки доступны в Настройках Модов!

--- a/UI/LobbyMapUI.cs
+++ b/UI/LobbyMapUI.cs
@@ -62,7 +62,6 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private readonly Wiggler closeWiggler;
         private readonly Wiggler confirmWiggler;
         private readonly Wiggler zoomWiggler;
-        private readonly SineWave notifySineWave;
 
         // current view
         private readonly float[] zoomLevels = { 1f, 2f, 3f };
@@ -92,7 +91,6 @@ namespace Celeste.Mod.CollabUtils2.UI {
         private bool openedWithRevealMap;
         private readonly bool viewOnly;
         private Vector2 initialPlayerCenter;
-        private float missingKeybindsTimeRemaining;
 
         #endregion
 
@@ -124,7 +122,6 @@ namespace Celeste.Mod.CollabUtils2.UI {
             Add(closeWiggler = Wiggler.Create(0.4f, 4f));
             Add(confirmWiggler = Wiggler.Create(0.4f, 4f));
             Add(zoomWiggler = Wiggler.Create(0.4f, 4f));
-            Add(notifySineWave = new SineWave(1f));
 
             Add(new BeforeRenderHook(beforeRender));
             Add(new Coroutine(mapFocusRoutine()));
@@ -152,8 +149,6 @@ namespace Celeste.Mod.CollabUtils2.UI {
             base.Added(scene);
 
             openedWithRevealMap = CollabModule.Instance.SaveData.RevealMap;
-            missingKeybindsTimeRemaining = CollabModule.Instance.Settings.NewLobbyMapKeybindsNotified ? 0f : 5f;
-            CollabModule.Instance.Settings.NewLobbyMapKeybindsNotified = true;
 
             if (scene is Level level && level.Tracker.GetEntity<Player>() is Player player) {
                 initialPlayerCenter = player.Center;
@@ -823,16 +818,6 @@ namespace Celeste.Mod.CollabUtils2.UI {
             } else if (hasLatestBinding(CollabModule.Instance.Settings.HoldToPan.Binding)) {
                 // draw the "hold to pan" input if it's bound
                 ButtonHelper.RenderMultiButton(ref buttonPosition, xOffset, holdToPanButtonRenderInfo, buttonScale, panAlpha, justifyX: 1f, wiggle: wiggleAmount);
-            }
-
-            // let the player know that there are new keybinds available
-            if (missingKeybindsTimeRemaining > 0) {
-                missingKeybindsTimeRemaining -= Engine.DeltaTime;
-                var notifyAlpha = Calc.Clamp(missingKeybindsTimeRemaining, 0f, 1f);
-                var notifyText = Dialog.Clean("collabutils2_lobbymap_notify_keybinds");
-                var notifyScale = 0.8f + notifySineWave.Value * 0.05f;
-                const float notifyOffset = 30f;
-                ActiveFont.DrawOutline(notifyText, new Vector2(windowBounds.Center.X, windowBounds.Top + notifyOffset), new Vector2(0.5f), new Vector2(notifyScale), Color.White * notifyAlpha, 2f, Color.Black * notifyAlpha);
             }
         }
 


### PR DESCRIPTION
The keybind notification is supposed to only show once if it detects that you have no lobby map keybinds set, but this logic is missing or incorrect.  Instead I've just removed the entire notification since it's been almost a year now.

Also added some default keybinds where it makes sense.  Hopefully they shouldn't conflict with anybody's existing bindings, and they will only apply while actually in the lobby and in a valid place and state to open the map.