### PR TITLE
Prevent mini heart from being broken multiple times

### DIFF
--- a/Entities/MiniHeart.cs
+++ b/Entities/MiniHeart.cs
@@ -12,7 +12,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
     [CustomEntity("CollabUtils2/MiniHeart")]
     public class MiniHeart : AbstractMiniHeart {
         private Sprite white;
-        private bool inCollectAnimation = false;
+        private bool hasBeenBroken = false;
         private readonly bool flash;
 
         private Coroutine smashRoutine;
@@ -26,12 +26,14 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         }
 
         protected override void heartBroken(Player player, Holdable holdable, Level level) {
+            if (hasBeenBroken) return;
+            
+            hasBeenBroken = true;
             Add(smashRoutine = new Coroutine(SmashRoutine(player, level)));
         }
 
         private IEnumerator SmashRoutine(Player player, Level level) {
             level.CanRetry = false;
-            inCollectAnimation = true;
 
             Collidable = false;
 
@@ -124,7 +126,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 white.SetAnimationFrame(sprite.CurrentAnimationFrame);
             }
 
-            if (inCollectAnimation && (Scene.Tracker.GetEntity<Player>()?.Dead ?? true)) {
+            if (hasBeenBroken && (Scene.Tracker.GetEntity<Player>()?.Dead ?? true)) {
                 interruptCollection();
             }
         }
@@ -162,7 +164,9 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         }
 
         private void stopMusic() {
-            pauseMusicSnapshot = Audio.CreateSnapshot("snapshot:/music_mains_mute");
+            if (pauseMusicSnapshot == null) {
+                pauseMusicSnapshot = Audio.CreateSnapshot("snapshot:/music_mains_mute");
+            }
             Audio.BusStopAll("bus:/gameplay_sfx", immediate: true);
         }
 


### PR DESCRIPTION
The code of the mini heart assumes that the SmashRoutine is never started twice. This is normally the case, as the heart is set to be not collidable after it has been collected once. However, if a mapper uses an entity such as an entity modifier to overwrite the collidability of the heart every frame, this assumption is no longer true. A very important sympom of this is that multiple music snapshots get made and only one gets released, fatally muting all music in the game until it is restarted. 
Of course, this would be an error on the mapper, but I still think the code should be robust enough to never let this happen.
This pull request adds logic to avoid the heart being broken multiple times. It also adds an extra safety check for the music stop code.