### PR TITLE
Add visiblity and interactibility flags to Warp Pedestals

### DIFF
--- a/Entities/WarpPedestal.cs
+++ b/Entities/WarpPedestal.cs
@@ -12,13 +12,18 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         private readonly bool allowSaving;
         private readonly string fillSoundEffect;
         private readonly int bubbleOffsetY;
+        private readonly string interactFlag;
+        private readonly string visibleFlag;
+        private readonly Sprite sprite;
 
-        public WarpPedestal(Vector2 position, string spriteName, string map, string returnToLobbyMode, bool allowSaving, string fillSoundEffect, int bubbleOffsetY) : base(position) {
+        public WarpPedestal(Vector2 position, string spriteName, string map, string returnToLobbyMode, bool allowSaving, string fillSoundEffect, int bubbleOffsetY, string interactFlag, string visibleFlag) : base(position) {
             this.map = map;
             this.returnToLobbyMode = returnToLobbyMode;
             this.allowSaving = allowSaving;
             this.fillSoundEffect = fillSoundEffect;
             this.bubbleOffsetY = bubbleOffsetY;
+            this.interactFlag = interactFlag;
+            this.visibleFlag = visibleFlag;
 
             // check if the map was already completed
             AreaData areaData = AreaData.Get(map);
@@ -42,7 +47,7 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 animation = "empty";
             }
 
-            Sprite sprite = GFX.SpriteBank.Create(spriteName);
+            sprite = GFX.SpriteBank.Create(spriteName);
             sprite.Play(animation);
             Add(sprite);
 
@@ -59,8 +64,9 @@ namespace Celeste.Mod.CollabUtils2.Entities {
         }
 
         public WarpPedestal(EntityData data, Vector2 offset) : this(data.Position + offset, data.Attr("sprite"), data.Attr("map"),
-            data.Attr("returnToLobbyMode"), data.Bool("allowSaving"), data.Attr("fillSoundEffect"), data.Int("bubbleOffsetY")) { }
-
+            data.Attr("returnToLobbyMode"), data.Bool("allowSaving"), data.Attr("fillSoundEffect"), data.Int("bubbleOffsetY"),
+            data.String("interactFlag",""), data.String("visibleFlag","")) { }
+        
         public override void Added(Scene scene) {
             base.Added(scene);
 
@@ -73,9 +79,16 @@ namespace Celeste.Mod.CollabUtils2.Entities {
                 Values = new Dictionary<string, object>() {
                     { "map", map },
                     { "returnToLobbyMode", returnToLobbyMode },
-                    { "allowSaving", allowSaving }
+                    { "allowSaving", allowSaving },
+                    { "interactFlag", interactFlag }
                 }
             }, Vector2.Zero));
+        }
+
+        public override void Update() {
+            base.Update();
+            if (string.IsNullOrWhiteSpace(visibleFlag)) return;
+            sprite.Visible = SceneAs<Level>()?.Session.GetFlag(visibleFlag) ?? true;
         }
     }
 }

--- a/Loenn/entities/warpPedestal.lua
+++ b/Loenn/entities/warpPedestal.lua
@@ -13,8 +13,23 @@ pedestal.placements = {
         returnToLobbyMode = "SetReturnToHere",
         allowSaving = true,
         fillSoundEffect = "",
-        bubbleOffsetY = 16
+        bubbleOffsetY = 16,
+        interactFlag = "",
+        visibleFlag = ""
     }
+}
+
+pedestal.fieldOrder = {
+    "x",
+    "y",
+    "map",
+    "sprite",
+    "returnToLobbyMode",
+    "fillSoundEffect",
+    "bubbleOffsetY",
+    "interactFlag",
+    "visibleFlag",
+    "allowSaving"
 }
 
 pedestal.fieldInformation = {
@@ -24,6 +39,12 @@ pedestal.fieldInformation = {
     returnToLobbyMode = {
         options = { "SetReturnToHere", "RemoveReturn", "DoNotChangeReturn" },
         editable = false
+    },
+    interactFlag = {
+        default = ""
+    },
+    visibleFlag = {
+        default = ""
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -57,6 +57,7 @@ triggers.CollabUtils2/ChapterPanelTrigger.attributes.description.map=The SID (st
 triggers.CollabUtils2/ChapterPanelTrigger.attributes.description.returnToLobbyMode=Determines how "Return to Lobby" will behave after entering this map.\n- SetReturnToHere: the Return to Lobby button will return the player to the nearest spawn point in the current map.\n- RemoveReturn: the Return to Lobby button will disappear from the pause menu.\n- DoNotChangeReturn: the current Return to Lobby button will not be changed.
 triggers.CollabUtils2/ChapterPanelTrigger.attributes.description.allowSaving=If selected, the player will be allowed to save and return to the lobby in the map this trigger teleports to, by selecting "Save" when returning to lobby. Not compatible with maps that have checkpoints.
 triggers.CollabUtils2/ChapterPanelTrigger.attributes.description.tech=Comma-separated list of tech used in the level, corresponding to gym names (e.g. hyper,wallbounce,cornerboost).\nFilling this out will make a second tab appear in the chapter panel,\nthat allows the player to a room teaching a tech (be sure to put a Gym Marker inside it).
+triggers.CollabUtils2/ChapterPanelTrigger.attributes.description.interactFlag=The flag that determines if the trigger is interactable.
 
 # Exit From Gym Trigger
 triggers.CollabUtils2/ExitFromGymTrigger.placements.name.default=Exit From Gym
@@ -146,3 +147,5 @@ entities.CollabUtils2/WarpPedestal.attributes.description.allowSaving=If selecte
 entities.CollabUtils2/WarpPedestal.attributes.description.sprite=The sprite to use for the pedestal, from your map's Sprites.xml.\nYou can use "CollabUtils2_placeholderOrb" in Collab Utils' own Sprites.xml as a reference.
 entities.CollabUtils2/WarpPedestal.attributes.description.bubbleOffsetY=The Y offset of the speech bubble above the pedestal. Bigger values will move the bubble up.
 entities.CollabUtils2/WarpPedestal.attributes.description.fillSoundEffect=The sound effect to play when the pedestal fills up / activates after beating a map for the first time.
+entities.CollabUtils2/WarpPedestal.attributes.description.interactFlag=The flag that determines if the pedestal is interactable.
+entities.CollabUtils2/WarpPedestal.attributes.description.visibleFlag=The flag that determines if the pedestal is visible.

--- a/Loenn/triggers/chapterPanelTrigger.lua
+++ b/Loenn/triggers/chapterPanelTrigger.lua
@@ -8,15 +8,32 @@ trigger.placements = {
             map = "Celeste/1-ForsakenCity",
             returnToLobbyMode = "SetReturnToHere",
             allowSaving = true,
-            tech = ""
+            tech = "",
+            interactFlag = ""
         }
     }
+}
+
+trigger.fieldOrder = {
+    "x",
+    "y",
+    "width",
+    "height",
+    "map",
+    "returnToLobbyMode",
+    "tech",
+    "interactFlag",
+    "allowSaving"
 }
 
 trigger.fieldInformation = {
     returnToLobbyMode = {
         options = { "SetReturnToHere", "RemoveReturn", "DoNotChangeReturn" },
         editable = false
+    },
+
+    interactFlag = {
+        default = ""
     }
 }
 

--- a/Triggers/ChapterPanelTrigger.cs
+++ b/Triggers/ChapterPanelTrigger.cs
@@ -10,9 +10,10 @@ namespace Celeste.Mod.CollabUtils2.Triggers {
         public enum ReturnToLobbyMode {
             SetReturnToHere, RemoveReturn, DoNotChangeReturn
         }
-
+        
         private readonly TalkComponent talkComponent;
-
+        private readonly string interactFlag;
+        
         public ChapterPanelTrigger(EntityData data, Vector2 offset)
             : base(data, offset) {
 
@@ -21,6 +22,8 @@ namespace Celeste.Mod.CollabUtils2.Triggers {
             bool savingAllowed = data.Bool("allowSaving", defaultValue: true);
             bool exitFromGym = data.Name == "CollabUtils2/ExitFromGymTrigger";
             bool markTechAsLearned = exitFromGym && data.Bool("markTechAsLearned");
+            interactFlag = data.Attr("interactFlag");
+            
 
             Add(talkComponent = new TalkComponent(
                 new Rectangle(0, 0, data.Width, data.Height),
@@ -52,7 +55,7 @@ namespace Celeste.Mod.CollabUtils2.Triggers {
 
         public override void Update() {
             base.Update();
-            talkComponent.Enabled = !InGameOverworldHelper.IsOpen;
+            talkComponent.Enabled = !InGameOverworldHelper.IsOpen && string.IsNullOrWhiteSpace(interactFlag) || (SceneAs<Level>()?.Session.GetFlag(interactFlag) ?? true);
         }
     }
 }


### PR DESCRIPTION
This PR implements the visibility and interactibility flags for both Warp Pedestals and Chapter Panel Triggers.
Enabling/disabling Warp pedestals and Chapter Panel Triggers is impossible by any other method,
so implementing this would be really useful.